### PR TITLE
Implement the Stringable trait and a prettier format on print.

### DIFF
--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -59,7 +59,7 @@ struct dataInfo[dtype: DType=DType.float32]():
             self.num_elements *= self.dims[i]
 
 # * COLUMN MAJOR INDEXING
-struct array[dtype: DType = DType.float32]():
+struct array[dtype: DType = DType.float32](Stringable):
     var _arr: DTypePointer[dtype]
     var _data_info: dataInfo[dtype]
     alias simd_width: Int = simdwidthof[dtype]()
@@ -259,7 +259,7 @@ struct array[dtype: DType = DType.float32]():
     fn __neg__(self) -> Self:
         return self * -1.0
 
-    fn __str__(inout self) -> String:
+    fn __str__(self) -> String:
         return self._array_to_string(0, self._data_info.first_index)
 
     fn _array_to_string(self, dimension:Int, offset:Int) -> String :
@@ -269,21 +269,20 @@ struct array[dtype: DType = DType.float32]():
         #     return "[" + ", ".join(self._array_to_string(dimension + 1, offset + i * self._data_info.weights[dimension]) for i in range(self._data_info.dims[dimension])) + "]"
 
         if dimension == len(self._data_info.dims) - 1:
-            var result:String = "["
+            var result: String = str("[\t")
             for i in range(self._data_info.dims[dimension]):
                 if i > 0:
-                    result = result + ", "
+                    result = result + "\t"
                 result = result + self._arr[offset + i * self._data_info.weights[dimension]].__str__()
                 # result = result + "0"
             result = result + "]"
             return result
         else:
-            var result = "["
+            var result: String = str("[")
             for i in range(self._data_info.dims[dimension]):
-                if i > 0:
-                    result = result + ", "
-                # result = result + self._array_to_string(dimension + 1, offset + i * self._data_info.weights[dimension])
-                result = result + "1"
+                result = result + self._array_to_string(dimension + 1, offset + i * self._data_info.weights[dimension])
+                if i < (self._data_info.dims[dimension]-1):
+                    result += "\n"
             result = result + "]"
             return result
 

--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -275,7 +275,7 @@ struct array[dtype: DType = DType.float32](Stringable):
                     result = result + "\t"
                 result = result + self._arr[offset + i * self._data_info.weights[dimension]].__str__()
                 # result = result + "0"
-            result = result + "]"
+            result = result + "\t]"
             return result
         else:
             var result: String = str("[")

--- a/test1.mojo
+++ b/test1.mojo
@@ -27,6 +27,8 @@ fn main() raises:
     ## ND arrays
     # * COLUMN MAJOR INDEXING
     var arr:array[DType.float64] = array[DType.float64](VariadicList[Int](2, 3, 3), random=True)
+    print(arr)
+
     print("2x3x3 ARRAY")
     print(arr[0,0,0], arr[0,1,0], arr[0,2,0], "\n",
         arr[1,0,0], arr[1,1,0], arr[1,2,0])

--- a/test1.mojo
+++ b/test1.mojo
@@ -26,7 +26,7 @@ fn main() raises:
 
     ## ND arrays
     # * COLUMN MAJOR INDEXING
-    var arr:array[DType.float64] = array[DType.float64](VariadicList[Int](2, 3, 3), random=True)
+    var arr = array[DType.int8](VariadicList[Int](5, 10), random=True)
     print(arr)
 
     print("2x3x3 ARRAY")


### PR DESCRIPTION
Implement the Stringable trait on array struct to enable `print()`.

Remove `inout` for the `__str__()` method.

Make a prettier format on print.

```mojo
[[      14      -94     -94     -126    99      -45     4       86      21      -122    ]
[       97      -48     -18     -88     -32     -71     83      -125    53      34      ]
[       -59     -40     42      -79     3       -13     26      -84     -86     15      ]
[       -4      66      -52     14      -42     18      61      66      -112    28      ]
[       112     -2      40      78      56      -102    -73     32      79      91      ]]
```