### PR TITLE
Add descriptions and examples to methods. Rename properties. New constructor.

### DIFF
--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -491,21 +491,45 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
     fn __str__(self) -> String:
         return self._array_to_string(0, 0)
 
-    fn _array_to_string(self, dimension:Int, offset:Int) -> String :
+    fn _array_to_string(self, dimension:Int, offset:Int) -> String:
         if dimension == self.info.ndim - 1:
             var result: String = str("[\t")
-            for i in range(self.info.shape[dimension]):
-                if i > 0:
+            var number_of_items = self.info.shape[dimension]
+            if number_of_items <= 6:  # Print all items
+                for i in range(number_of_items):
+                    result = result + self._arr[offset + i * self.info.strides[dimension]].__str__()
                     result = result + "\t"
-                result = result + self._arr[offset + i * self.info.strides[dimension]].__str__()
-            result = result + "\t]"
+            else:  # Print first 3 and last 3 items
+                for i in range(3):
+                    result = result + self._arr[offset + i * self.info.strides[dimension]].__str__()
+                    result = result + "\t"
+                result = result + "...\t"
+                for i in range(number_of_items-3, number_of_items):
+                    result = result + self._arr[offset + i * self.info.strides[dimension]].__str__()
+                    result = result + "\t"
+            result = result + "]"
             return result
         else:
             var result: String = str("[")
-            for i in range(self.info.shape[dimension]):
-                result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
-                if i < (self.info.shape[dimension]-1):
-                    result += "\n"
+            var number_of_items = self.info.shape[dimension]
+            if number_of_items <= 6:  # Print all items
+                for i in range(number_of_items):
+                    if i == 0:
+                        result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                    if i > 0:
+                        result = result + str(" ") * (dimension+1) + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                    if i < (number_of_items-1):
+                        result = result + "\n"
+            else:  # Print first 3 and last 3 items
+                    for i in range(3):
+                        result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                        if i < (number_of_items-1):
+                            result += "\n"
+                    result = result + "...\n"
+                    for i in range(number_of_items-3, number_of_items):
+                        result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                        if i < (number_of_items-1):
+                            result = result + "\n"
             result = result + "]"
             return result
 

--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -251,6 +251,36 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         if random:
             rand[dtype](self._arr, size)
 
+    fn __init__(inout self, data: List[SIMD[dtype, 1]], shape: List[Int]):
+        """
+        Example:
+            `NDArray[DType.int8](List[Int8](1,2,3,4,5,6), shape=List[Int](2,3))`
+            Returns an array with shape 3 x 2 with input values.
+        """
+
+        var dimension: Int = shape.__len__()
+        var first_index: Int = 0
+        var size: Int = 1
+        var shapeInfo: List[Int] = List[Int]()
+        var strides: List[Int] = List[Int]()
+
+        for i in range(dimension):
+            shapeInfo.append(shape[i])
+            size *= shape[i]
+            var temp: Int = 1
+            for j in range(1, i + 1):  # temp
+                temp *= shape[-j]
+            strides.append(temp)
+            strides = strides[::-1]
+
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
+        for i in range(size):
+            self._arr[i] = data[i]
+        self.info = arrayDescriptor[dtype](
+            dimension, first_index, size, shapeInfo, strides
+        )
+
     fn __init__(inout self, shape: List[Int], random: Bool = False):
         """
         Example:

--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -522,12 +522,15 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
                         result = result + "\n"
             else:  # Print first 3 and last 3 items
                     for i in range(3):
-                        result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                        if i == 0:
+                            result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                        if i > 0:
+                            result = result + str(" ") * (dimension+1) + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
                         if i < (number_of_items-1):
                             result += "\n"
                     result = result + "...\n"
                     for i in range(number_of_items-3, number_of_items):
-                        result = result + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
+                        result = result + str(" ") * (dimension+1) + self._array_to_string(dimension + 1, offset + i * self.info.strides[dimension])
                         if i < (number_of_items-1):
                             result = result + "\n"
             result = result + "]"

--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -111,9 +111,9 @@ struct NDArrayShape[dtype:DType = DType.int32](Stringable):
 
 @value
 struct arrayDescriptor[dtype: DType = DType.float32]():
-    var ndim: Int
+    var ndim: Int  # Number of dimensions of the array
     var offset_index: Int
-    var num_elements: Int
+    var size: Int  # Number of elements in the array
     var shape: List[Int]  # size of each dimension
     var strides: List[Int]  # strides
     var coefficients: List[Int]  # coefficients
@@ -122,14 +122,14 @@ struct arrayDescriptor[dtype: DType = DType.float32]():
         inout self,
         ndim: Int,
         offset_index: Int,
-        num_elements: Int,
+        size: Int,
         shape: List[Int],
         strides: List[Int],
         coefficients: List[Int] = List[Int](),
     ):
         self.ndim = ndim
         self.offset_index = offset_index
-        self.num_elements = num_elements
+        self.size = size
         self.shape = shape
         self.strides = strides
         self.coefficients = coefficients
@@ -144,49 +144,49 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
     fn __init__(inout self, *shape: Int):
         var dimension: Int = shape.__len__()
         var first_index: Int = 0
-        var num_elements: Int = 1
+        var size: Int = 1
         var shapeInfo: List[Int] = List[Int]()
         var strides: List[Int] = List[Int]()
 
         print(shape[0], shape[1])
         for i in range(dimension):
             shapeInfo.append(shape[i])
-            num_elements *= shape[i]
+            size *= shape[i]
             var temp: Int = 1
             for j in range(i + 1):  # temp
                 temp *= shape[j]
             strides.append(temp)
 
-        self._arr = DTypePointer[dtype].alloc(num_elements)
-        memset_zero(self._arr, num_elements)
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
         self.info = arrayDescriptor[dtype](
-            dimension, first_index, num_elements, shapeInfo, strides
+            dimension, first_index, size, shapeInfo, strides
         )
     
     fn __init__(inout self, shape: NDArrayShape, random: Bool = False, value: SIMD[dtype, 1] = SIMD[dtype, 1](0)):
         var dimension: Int = shape.shape.__len__()
         var first_index: Int = 0
-        var num_elements: Int = 1
+        var size: Int = 1
         var shapeInfo: List[Int] = List[Int]()
         var strides: List[Int] = List[Int]()
 
         for i in range(dimension):
             shapeInfo.append(shape.shape[i])
-            num_elements *= shape.shape[i]
+            size *= shape.shape[i]
             var temp: Int = 1
             for j in range(i + 1, dimension):  # temp
                 temp *= shape.shape[j]
             strides.append(temp)
 
-        self._arr = DTypePointer[dtype].alloc(num_elements)
-        memset_zero(self._arr, num_elements)
-        for i in range(num_elements):
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
+        for i in range(size):
             self._arr[i] = value
         self.info = arrayDescriptor[dtype](
-            dimension, first_index, num_elements, shapeInfo, strides
+            dimension, first_index, size, shapeInfo, strides
         )
         if random:
-            rand[dtype](self._arr, num_elements)
+            rand[dtype](self._arr, size)
     
 
     # constructor when rank, ndim, weights, first_index(offset) are known
@@ -194,68 +194,68 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         inout self,
         ndim: Int,
         offset_index: Int,
-        num_elements: Int,
+        size: Int,
         shape: List[Int],
         strides: List[Int],
         coefficients: List[Int] = List[Int](),
     ):
-        self._arr = DTypePointer[dtype].alloc(num_elements)
-        memset_zero(self._arr, num_elements)
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
         self.info = arrayDescriptor[dtype](
-            ndim, offset_index, num_elements, shape, strides, coefficients
+            ndim, offset_index, size, shape, strides, coefficients
         )
 
     fn __init__(inout self, shape: VariadicList[Int], random: Bool = False):
         var dimension: Int = shape.__len__()
         var first_index: Int = 0
-        var num_elements: Int = 1
+        var size: Int = 1
         var shapeInfo: List[Int] = List[Int]()
         var strides: List[Int] = List[Int]()
 
         for i in range(dimension):
             shapeInfo.append(shape[i])
-            num_elements *= shape[i]
+            size *= shape[i]
             var temp: Int = 1
             for j in range(i + 1, shape.__len__()):  # temp
                 temp *= shape[j]
             strides.append(temp)
 
-        self._arr = DTypePointer[dtype].alloc(num_elements)
-        memset_zero(self._arr, num_elements)
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
         self.info = arrayDescriptor[dtype](
-            dimension, first_index, num_elements, shapeInfo, strides
+            dimension, first_index, size, shapeInfo, strides
         )
 
         if random:
-            rand[dtype](self._arr, num_elements)
+            rand[dtype](self._arr, size)
 
     fn __init__(inout self, shape: List[Int], random: Bool = False):
         var dimension: Int = shape.__len__()
         var first_index: Int = 0
-        var num_elements: Int = 1
+        var size: Int = 1
         var shapeInfo: List[Int] = List[Int]()
         var strides: List[Int] = List[Int]()
 
         for i in range(dimension):
             shapeInfo.append(shape[i])
-            num_elements *= shape[i]
+            size *= shape[i]
             var temp: Int = 1
             for j in range(i + 1):  # temp
                 temp *= shape[j]
             strides.append(temp)
 
-        self._arr = DTypePointer[dtype].alloc(num_elements)
-        memset_zero(self._arr, num_elements)
+        self._arr = DTypePointer[dtype].alloc(size)
+        memset_zero(self._arr, size)
         self.info = arrayDescriptor[dtype](
-            dimension, first_index, num_elements, shapeInfo, strides
+            dimension, first_index, size, shapeInfo, strides
         )
         if random:
-            rand[dtype](self._arr, num_elements)
+            rand[dtype](self._arr, size)
 
     fn __copyinit__(inout self, new: Self):
         self.info = new.info
-        self._arr = DTypePointer[dtype].alloc(new.info.num_elements)
-        for i in range(new.info.num_elements):
+        self._arr = DTypePointer[dtype].alloc(new.info.size)
+        for i in range(new.info.size):
             self._arr[i] = new._arr[i]
 
     fn __moveinit__(inout self, owned existing: Self):
@@ -421,14 +421,14 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
     #     var index: Int = _get_index(indices, self.info.strides)
     #     self._arr.store[width=width](index, val)
 
-    fn num_elements(self) -> Int:
-        return self.info.num_elements
+    fn size(self) -> Int:
+        return self.info.size
 
     fn __len__(inout self) -> Int:
-        return self.info.num_elements
+        return self.info.size
 
     fn __int__(self) -> Int:
-        return self.info.num_elements
+        return self.info.size
 
     fn __pos__(self) -> Self:
         return self * 1.0
@@ -479,7 +479,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
                 ),
             )
 
-        vectorize[elemwise_vectorize, simd_width](self.info.num_elements)
+        vectorize[elemwise_vectorize, simd_width](self.info.size)
         return new_array
 
     fn _elementwise_array_arithmetic[
@@ -500,7 +500,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
                 ),
             )
 
-        vectorize[elemwise_arithmetic, simd_width](self.info.num_elements)
+        vectorize[elemwise_arithmetic, simd_width](self.info.size)
         return new_vec
 
     fn __add__(inout self, other: Scalar[dtype]) -> Self:
@@ -547,7 +547,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         fn vectorize_reduce[simd_width: Int](idx: Int) -> None:
             reduced[0] += self._arr.load[width=simd_width](idx).reduce_add()
 
-        vectorize[vectorize_reduce, simd_width](self.info.num_elements)
+        vectorize[vectorize_reduce, simd_width](self.info.size)
         return reduced
 
     fn __matmul__(self, other: Self) -> Scalar[dtype]:
@@ -559,7 +559,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         """
         Inner product of two vectors.
         """
-        if self.info.num_elements != other.info.num_elements:
+        if self.info.size != other.info.size:
             raise Error("The lengths of two vectors do not match.")
         return self._elementwise_array_arithmetic[SIMD.__mul__](
             other
@@ -607,7 +607,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
                 idx, pow(self._arr.load[width=simd_width](idx), p)
             )
 
-        vectorize[tensor_scalar_vectorize, simd_width](self.info.num_elements)
+        vectorize[tensor_scalar_vectorize, simd_width](self.info.size)
         return new_vec
 
     # ! truediv is multiplying instead of dividing right now lol, I don't know why.
@@ -615,7 +615,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         return self._elementwise_scalar_arithmetic[SIMD.__truediv__](s)
 
     fn __truediv__(self, other: Self) raises -> Self:
-        if self.info.num_elements != other.info.num_elements:
+        if self.info.size != other.info.size:
             raise Error("No of elements in both arrays do not match")
 
         return self._elementwise_array_arithmetic[SIMD.__truediv__](other)

--- a/numojo/ndarray.mojo
+++ b/numojo/ndarray.mojo
@@ -506,6 +506,9 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
     fn size(self) -> Int:
         return self.info.size
 
+    fn num_elements(self) -> Int:
+        return self.info.size
+
     fn __len__(inout self) -> Int:
         return self.info.size
 

--- a/test_rowmajor.mojo
+++ b/test_rowmajor.mojo
@@ -5,21 +5,23 @@ from testing import assert_raises
 
 from numojo.ndarray import NDArray
 
+import time
+
 fn main() raises:
     ## ND arrays
-    var orig = NDArray[DType.float16](VariadicList[Int](2, 2), random=True)
-    print(orig, "\n")
-    var narr = NDArray[DType.float16](VariadicList[Int](2, 2), random=True)
-    print(narr, "\n")
+    var t0 = time.now()
+
+    var orig = NDArray[DType.float32](VariadicList[Int](100, 100), random=True)
+    var narr = NDArray[DType.float32](VariadicList[Int](100, 100), random=True)
     # var index = List[Int](0, 0)
     # numojo.ndarray._traverse_iterative[DType.float16](orig, narr, orig._arrayInfo.dims, orig._arrayInfo.weights, 0, index, 0)
-    # print(narr)
-    print(orig.mdot(narr), "\n")
-    print(orig.vdot(narr), "\n")
+    var _temp = orig.mdot(narr)
+    print(_temp)
+    print((time.now()-t0)/10e9, "seconds")
 
     # # * ROW MAJOR INDEXING
-    var arr = NDArray[DType.float16](VariadicList[Int](2, 3, 3), random=True)
-    print("2x3x3 array row major")
+    var arr = NDArray[DType.int64](VariadicList[Int](2, 2, 2), random=True)
+    print("2x2x2 array row major")
     print(arr)
     print()
     # # slicing doesn't support single integer index for now, therefore [:,:,2] 

--- a/test_rowmajor.mojo
+++ b/test_rowmajor.mojo
@@ -11,6 +11,9 @@ fn main() raises:
     ## ND arrays
     var t0 = time.now()
 
+    var new = NDArray[DType.int8](List[Int8](1,2,3,4,5,6), shape=List[Int](2,3))
+    print(new)
+
     var orig = NDArray[DType.float32](VariadicList[Int](100, 100), random=True)
     var narr = NDArray[DType.float32](VariadicList[Int](100, 100), random=True)
     # var index = List[Int](0, 0)
@@ -20,8 +23,8 @@ fn main() raises:
     print((time.now()-t0)/10e9, "seconds")
 
     # # * ROW MAJOR INDEXING
-    var arr = NDArray[DType.int64](VariadicList[Int](2, 2, 2), random=True)
-    print("2x2x2 array row major")
+    var arr = NDArray[DType.int64](VariadicList[Int](2, 2, 2, 2), random=True)
+    print("2x2x2x2 array row major")
     print(arr)
     print()
     # # slicing doesn't support single integer index for now, therefore [:,:,2] 


### PR DESCRIPTION
- rename "dims" to "ndim" as used in numpy.
- Rename "num_elements" to "size" as used in numpy.
- Unify "offset" and "offset_index".

Add descriptions and examples to methods.

New constructor that reads in a list of values and a given shape:

```
var new = NDArray[DType.int8](List[Int8](1,2,3,4,5,6), shape=List[Int](2,3))
print(new)
```
```
[[      1       2       3       ]
 [      4       5       6       ]]
```

Prettifier the print of array:
- Brackets are aligned.
- Too big matrices will only display 6 items. Others are hidden with "..."

Example
```
2x2x2 array row major
[[[     -2539847201920768954    -2954198200105729586    ]
  [     -6823962921516992944    2029935122236413610     ]]
 [[     7633668494833173590     4354125810055772268     ]
  [     -9123853686718177380    3949498256491946437     ]]]
```

```
[[      28.460910797119141      27.017505645751953      29.514076232910156      ...     26.757898330688477      24.833465576171875      29.247947692871094      ]
 [      26.933135986328125      24.412242889404297      26.625005722045898      ...     28.712247848510742      24.744485855102539      28.799398422241211      ]
 [      28.047012329101562      27.378717422485352      25.488777160644531      ...     28.626455307006836      23.649147033691406      30.006862640380859      ]
...
 [      24.701332092285156      24.06718635559082       23.429698944091797      ...     24.488513946533203      22.443071365356445      25.786645889282227      ]
 [      30.854358673095703      28.262357711791992      29.71173095703125       ...     31.474330902099609      28.698692321777344      30.207204818725586      ]
 [      30.164535522460938      29.846334457397461      30.619012832641602      ...     31.356224060058594      28.940071105957031      33.840545654296875      ]]
```

