### PR TITLE
Making `A.shape` the way to get the `NDArrayShape` of an array

### DIFF
--- a/numojo/core/_array_funcs.mojo
+++ b/numojo/core/_array_funcs.mojo
@@ -27,7 +27,7 @@ fn math_func_1_array_in_one_array_out[
     Returns:
         A new NDArray that is the result of applying the function to the NDArray.
     """
-    var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+    var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
     alias width = simdwidthof[dtype]()
 
     @parameter
@@ -66,10 +66,10 @@ fn math_func_2_array_in_one_array_out[
         A new NDArray that is the result of applying the function to the input NDArrays.
     """
 
-    if array1.shape() != array2.shape():
+    if array1.shape != array2.shape:
         raise Error("Shape Mismatch error shapes must match for this function")
 
-    var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+    var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
     alias width = simdwidthof[dtype]()
 
     @parameter
@@ -106,7 +106,7 @@ fn math_func_one_array_one_SIMD_in_one_array_out[
         A new NDArray that is the result of applying the function to the input NDArray and SIMD value.
     """
 
-    var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+    var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
     alias width = simdwidthof[dtype]()
 
     @parameter

--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -435,7 +435,7 @@ fn empty_like[
     Returns:
         A NDArray of `dtype` with the same shape as `array`.
     """
-    return NDArray[dtype](shape=array.ndshape)
+    return NDArray[dtype](shape=array.shape)
 
 
 fn eye[dtype: DType = DType.float64](N: Int, M: Int) raises -> NDArray[dtype]:
@@ -528,7 +528,7 @@ fn ones_like[
     Returns:
         A NDArray of `dtype` with the same shape as `a` filled with ones.
     """
-    return ones[dtype](shape=array.ndshape)
+    return ones[dtype](shape=array.shape)
 
 
 fn zeros[
@@ -582,7 +582,7 @@ fn zeros_like[
     Returns:
         A NDArray of `dtype` with the same shape as `a` filled with zeros.
     """
-    return full[dtype](shape=array.ndshape, fill_value=0)
+    return full[dtype](shape=array.shape, fill_value=0)
 
 
 fn full[
@@ -622,7 +622,7 @@ fn full_like[
     Returns:
         A NDArray of `dtype` with the same shape as `a` filled with `fill_value`.
     """
-    return full[dtype](shape=array.ndshape, fill_value=fill_value)
+    return full[dtype](shape=array.shape, fill_value=fill_value)
 
 
 # ===------------------------------------------------------------------------===#
@@ -645,7 +645,7 @@ fn diag[
         A 1-D NDArray with the diagonal of the input NDArray.
     """
     if v.ndim == 1:
-        var n: Int = v.ndshape.ndsize
+        var n: Int = v.shape.ndsize
         var result: NDArray[dtype] = zeros[dtype](shape(n + abs(k), n + abs(k)))
         if k >= 0:
             for i in range(n):
@@ -654,12 +654,12 @@ fn diag[
         else:
             for i in range(n):
                 result._buf[
-                    result.ndshape.ndsize - 1 - i * (result.ndshape[1] + 1) + k
+                    result.shape.ndsize - 1 - i * (result.shape[1] + 1) + k
                 ] = v._buf[n - 1 - i]
         return result^
     elif v.ndim == 2:
-        var m: Int = v.ndshape[0]
-        var n: Int = v.ndshape[1]
+        var m: Int = v.shape[0]
+        var n: Int = v.shape[1]
         var result: NDArray[dtype] = NDArray[dtype](Shape(n - abs(k)))
         if k >= 0:
             for i in range(n - abs(k)):
@@ -667,7 +667,7 @@ fn diag[
         else:
             for i in range(n - abs(k)):
                 result._buf[m - abs(k) - 1 - i] = v._buf[
-                    v.ndshape.ndsize - 1 - i * (v.ndshape[1] + 1) + k
+                    v.shape.ndsize - 1 - i * (v.shape[1] + 1) + k
                 ]
         return result^
     else:
@@ -690,7 +690,7 @@ fn diagflat[
     Returns:
         A 2-D NDArray with the flattened input as the diagonal.
     """
-    var n: Int = v.ndshape.ndsize
+    var n: Int = v.shape.ndsize
     var result: NDArray[dtype] = zeros[dtype](shape(n + abs(k), n + abs(k)))
     if k >= 0:
         for i in range(n):
@@ -698,8 +698,8 @@ fn diagflat[
     else:
         for i in range(n):
             result.store(
-                result.ndshape.ndsize - 1 - (n + abs(k) + 1) * i + k,
-                v._buf[v.ndshape.ndsize - 1 - i],
+                result.shape.ndsize - 1 - (n + abs(k) + 1) * i + k,
+                v._buf[v.shape.ndsize - 1 - i],
             )
     return result^
 
@@ -749,21 +749,19 @@ fn tril[
     var final_offset: Int = 1
     var result: NDArray[dtype] = m
     if m.ndim == 2:
-        for i in range(m.ndshape[0]):
-            for j in range(i + 1 + k, m.ndshape[1]):
-                result._buf[i * m.ndshape[1] + j] = Scalar[dtype](0)
+        for i in range(m.shape[0]):
+            for j in range(i + 1 + k, m.shape[1]):
+                result._buf[i * m.shape[1] + j] = Scalar[dtype](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
-            initial_offset *= m.ndshape[i]
+            initial_offset *= m.shape[i]
         for i in range(m.ndim - 2, m.ndim):
-            final_offset *= m.ndshape[i]
+            final_offset *= m.shape[i]
         for offset in range(initial_offset):
             offset = offset * final_offset
-            for i in range(m.ndshape[-2]):
-                for j in range(i + 1 + k, m.ndshape[-1]):
-                    result._buf[offset + j + i * m.ndshape[-1]] = Scalar[dtype](
-                        0
-                    )
+            for i in range(m.shape[-2]):
+                for j in range(i + 1 + k, m.shape[-1]):
+                    result._buf[offset + j + i * m.shape[-1]] = Scalar[dtype](0)
     else:
         raise Error(
             "Arrays smaller than 2D are not supported for this operation."
@@ -791,21 +789,19 @@ fn triu[
     var final_offset: Int = 1
     var result: NDArray[dtype] = m
     if m.ndim == 2:
-        for i in range(m.ndshape[0]):
+        for i in range(m.shape[0]):
             for j in range(0, i + k):
-                result._buf[i * m.ndshape[1] + j] = Scalar[dtype](0)
+                result._buf[i * m.shape[1] + j] = Scalar[dtype](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
-            initial_offset *= m.ndshape[i]
+            initial_offset *= m.shape[i]
         for i in range(m.ndim - 2, m.ndim):
-            final_offset *= m.ndshape[i]
+            final_offset *= m.shape[i]
         for offset in range(initial_offset):
             offset = offset * final_offset
-            for i in range(m.ndshape[-2]):
+            for i in range(m.shape[-2]):
                 for j in range(0, i + k):
-                    result._buf[offset + j + i * m.ndshape[-1]] = Scalar[dtype](
-                        0
-                    )
+                    result._buf[offset + j + i * m.shape[-1]] = Scalar[dtype](0)
     else:
         raise Error(
             "Arrays smaller than 2D are not supported for this operation."
@@ -835,7 +831,7 @@ fn vander[
     if x.ndim != 1:
         raise Error("x must be a 1-D array")
 
-    var n_rows = x.ndshape.ndsize
+    var n_rows = x.shape.ndsize
     var n_cols = N.value() if N else n_rows
     var result: NDArray[dtype] = ones[dtype](NDArrayShape(n_rows, n_cols))
     for i in range(n_rows):

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -34,7 +34,7 @@ fn shape[dtype: DType](array: NDArray[dtype]) -> NDArrayShape:
     Returns:
         The shape of the NDArray.
     """
-    return array.ndshape
+    return array.shape
 
 
 fn size[dtype: DType](array: NDArray[dtype], axis: Int) raises -> Int:
@@ -48,7 +48,7 @@ fn size[dtype: DType](array: NDArray[dtype], axis: Int) raises -> Int:
     Returns:
         The size of the NDArray.
     """
-    return array.ndshape[axis]
+    return array.shape[axis]
 
 
 fn reshape[
@@ -74,7 +74,7 @@ fn reshape[
         num_elements_new *= i
         ndim_new += 1
 
-    if array.ndshape.ndsize != num_elements_new:
+    if array.shape.ndsize != num_elements_new:
         raise Error("Cannot reshape: Number of elements do not match.")
 
     var shape_new: List[Int] = List[Int]()
@@ -85,7 +85,7 @@ fn reshape[
             temp *= shape[j]
 
     array.ndim = ndim_new
-    array.ndshape = NDArrayShape(shape=shape_new)
+    array.shape = NDArrayShape(shape=shape_new)
     array.stride = NDArrayStride(shape=shape_new, order=order)
     array.order = order
 
@@ -99,9 +99,9 @@ fn ravel[dtype: DType](inout array: NDArray[dtype], order: String = "C") raises:
         return
     else:
         if order == "C":
-            reshape[dtype](array, array.ndshape.ndsize, order="C")
+            reshape[dtype](array, array.shape.ndsize, order="C")
         else:
-            reshape[dtype](array, array.ndshape.ndsize, order="F")
+            reshape[dtype](array, array.shape.ndsize, order="F")
 
 
 fn where[
@@ -121,7 +121,7 @@ fn where[
         mask: A NDArray.
 
     """
-    for i in range(x.ndshape.ndsize):
+    for i in range(x.shape.ndsize):
         if mask._buf[i] == True:
             x._buf.store(i, scalar)
 
@@ -145,9 +145,9 @@ fn where[
         mask: NDArray[DType.bool].
 
     """
-    if x.ndshape != y.ndshape:
+    if x.shape != y.shape:
         raise Error("Shape mismatch error: x and y must have the same shape")
-    for i in range(x.ndshape.ndsize):
+    for i in range(x.shape.ndsize):
         if mask._buf[i] == True:
             x._buf.store(i, y._buf[i])
 
@@ -169,10 +169,10 @@ fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         raise Error("Flip is only supported for 1D arrays")
 
     var result: NDArray[dtype] = NDArray[dtype](
-        shape=array.ndshape, order=array.order
+        shape=array.shape, order=array.order
     )
-    for i in range(array.ndshape.ndsize):
-        result._buf.store(i, array._buf[array.ndshape.ndsize - i - 1])
+    for i in range(array.shape.ndsize):
+        result._buf.store(i, array._buf[array.shape.ndsize - i - 1])
     return result
 
 
@@ -190,7 +190,7 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         The 1 dimensional flattened NDArray.
     """
 
-    var res: NDArray[dtype] = NDArray[dtype](array.ndshape.ndsize)
+    var res: NDArray[dtype] = NDArray[dtype](array.shape.ndsize)
     alias width: Int = simdwidthof[dtype]()
 
     @parameter
@@ -199,7 +199,7 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
             index, array._buf.load[width=simd_width](index)
         )
 
-    vectorize[vectorized_flatten, width](array.ndshape.ndsize)
+    vectorize[vectorized_flatten, width](array.shape.ndsize)
     return res
 
 
@@ -229,8 +229,8 @@ fn trace[
     if axis1 > array.ndim - 1 or axis2 > array.ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
     var result: NDArray[dtype] = NDArray[dtype](1)
-    var rows = array.ndshape[0]
-    var cols = array.ndshape[1]
+    var rows = array.shape[0]
+    var cols = array.shape[1]
     var diag_length = min(rows, cols - offset) if offset >= 0 else min(
         rows + offset, cols
     )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -143,7 +143,7 @@ struct NDArray[dtype: DType = DType.float64](
     """Data buffer of the items in the NDArray."""
     var ndim: Int
     """Number of Dimensions."""
-    var ndshape: NDArrayShape
+    var shape: NDArrayShape
     """Size and shape of NDArray."""
     var stride: NDArrayStride
     """Contains offset, strides."""
@@ -185,14 +185,14 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         self.ndim = shape.__len__()
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self._buf, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buf, self.shape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -217,14 +217,14 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         self.ndim = shape.__len__()
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self._buf, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buf, self.shape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -249,14 +249,14 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         self.ndim = shape.__len__()
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self._buf, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buf, self.shape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -281,14 +281,14 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         self.ndim = shape.ndlen
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, order=order)
         self.coefficient = NDArrayStride(shape, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self._buf, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buf, self.shape.ndsize, fill.value())
 
     fn __init__(
         inout self,
@@ -312,13 +312,13 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         self.ndim = shape.ndlen
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
         self.datatype = dtype
         self.order = order
-        for i in range(self.ndshape.ndsize):
+        for i in range(self.shape.ndsize):
             self._buf[i] = data[i]
 
     fn __init__(inout self, data: PythonObject, order: String = "C") raises:
@@ -344,14 +344,14 @@ struct NDArray[dtype: DType = DType.float64](
                 continue
             shape.append(int(data.shape[i]))
         self.ndim = shape.__len__()
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
-        memset_zero(self._buf, self.ndshape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
+        memset_zero(self._buf, self.shape.ndsize)
         self.order = order
         self.datatype = dtype
-        for i in range(self.ndshape.ndsize):
+        for i in range(self.shape.ndsize):
             self._buf[i] = data.item(PythonObject(i)).to_float64().cast[dtype]()
 
     # Why do  these last two constructors exist?
@@ -370,7 +370,7 @@ struct NDArray[dtype: DType = DType.float64](
         Extremely specific NDArray initializer.
         """
         self.ndim = ndim
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(stride=strides, offset=0)
         self.coefficient = NDArrayStride(stride=coefficient, offset=offset)
         self.datatype = dtype
@@ -393,7 +393,7 @@ struct NDArray[dtype: DType = DType.float64](
         Extremely specific NDArray initializer.
         """
         self.ndim = ndim
-        self.ndshape = NDArrayShape(shape)
+        self.shape = NDArrayShape(shape)
         self.stride = NDArrayStride(strides, offset=0, order=order)
         self.coefficient = NDArrayStride(
             coefficient, offset=offset, order=order
@@ -408,13 +408,13 @@ struct NDArray[dtype: DType = DType.float64](
         Copy other into self.
         """
         self.ndim = other.ndim
-        self.ndshape = other.ndshape
+        self.shape = other.shape
         self.stride = other.stride
         self.coefficient = other.coefficient
         self.datatype = other.datatype
         self.order = other.order
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(other.ndshape.size())
-        memcpy(self._buf, other._buf, other.ndshape.size())
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(other.shape.size())
+        memcpy(self._buf, other._buf, other.shape.size())
 
     @always_inline("nodebug")
     fn __moveinit__(inout self, owned existing: Self):
@@ -422,7 +422,7 @@ struct NDArray[dtype: DType = DType.float64](
         Move other into self.
         """
         self.ndim = existing.ndim
-        self.ndshape = existing.ndshape
+        self.shape = existing.shape
         self.stride = existing.stride
         self.coefficient = existing.coefficient
         self.datatype = existing.datatype
@@ -455,12 +455,12 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
-        if index >= self.ndshape.ndsize:
+        if index >= self.shape.ndsize:
             raise Error("Invalid index: index out of bound")
         if index >= 0:
             return self._buf.store[width=1](index, val)
         else:
-            return self._buf.store[width=1](index + self.ndshape.ndsize, val)
+            return self._buf.store[width=1](index + self.shape.ndsize, val)
 
     # TODO: add support for different dtypes
     fn __setitem__(inout self, idx: Int, val: NDArray[dtype]) raises:
@@ -477,7 +477,7 @@ struct NDArray[dtype: DType = DType.float64](
         slice_list.append(Slice(idx, idx + 1))
         if self.ndim > 1:
             for i in range(1, self.ndim):
-                var size_at_dim: Int = self.ndshape[i]
+                var size_at_dim: Int = self.shape[i]
                 slice_list.append(Slice(0, size_at_dim))
 
         var n_slices: Int = len(slice_list)
@@ -485,10 +485,10 @@ struct NDArray[dtype: DType = DType.float64](
         var count: Int = 0
         var spec: List[Int] = List[Int]()
         for i in range(n_slices):
-            # self._adjust_slice_(slice_list[i], self.ndshape[i])
+            # self._adjust_slice_(slice_list[i], self.shape[i])
             if (
-                slice_list[i].start.value() >= self.ndshape[i]
-                or slice_list[i].end.value() > self.ndshape[i]
+                slice_list[i].start.value() >= self.shape[i]
+                or slice_list[i].end.value() > self.shape[i]
             ):
                 raise Error("Error: Slice value exceeds the array shape")
             var slice_len: Int = (
@@ -527,7 +527,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # We can remove this check after we have support for broadcasting
         for i in range(ndims):
-            if nshape[i] != val.ndshape[i]:
+            if nshape[i] != val.shape[i]:
                 raise Error(
                     "Error: Shape mismatch, Cannot set the array values with"
                     " given array"
@@ -566,7 +566,7 @@ struct NDArray[dtype: DType = DType.float64](
         if index.__len__() != self.ndim:
             raise Error("Error: Length of Indices do not match the shape")
         for i in range(index.__len__()):
-            if index[i] >= self.ndshape[i]:
+            if index[i] >= self.shape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
         var idx: Int = _get_index(index, self.coefficient)
         self._buf.store[width=1](idx, val)
@@ -579,11 +579,11 @@ struct NDArray[dtype: DType = DType.float64](
     #     Set the value of the array at the indices where the mask is true.
     #     """
     #     if (
-    #         mask.ndshape != self.ndshape
+    #         mask.shape != self.shape
     #     ):  # this behavious could be removed potentially
     #         raise Error("Mask and array must have the same shape")
 
-    #     for i in range(mask.ndshape.ndsize):
+    #     for i in range(mask.shape.ndsize):
     #         if mask._buf.load[width=1](i):
     #             print(value)
     #             self._buf.store[width=1](i, value)
@@ -618,8 +618,8 @@ struct NDArray[dtype: DType = DType.float64](
         var slice_list: List[Slice] = self._adjust_slice_(slices)
         for i in range(n_slices):
             if (
-                slice_list[i].start.value() >= self.ndshape[i]
-                or slice_list[i].end.value() > self.ndshape[i]
+                slice_list[i].start.value() >= self.shape[i]
+                or slice_list[i].end.value() > self.shape[i]
             ):
                 raise Error("Error: Slice value exceeds the array shape")
             var slice_len: Int = (
@@ -658,7 +658,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # We can remove this check after we have support for broadcasting
         for i in range(ndims):
-            if nshape[i] != val.ndshape[i]:
+            if nshape[i] != val.shape[i]:
                 raise Error(
                     "Error: Shape mismatch, Cannot set the array values with"
                     " given array"
@@ -711,7 +711,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     #     if n_slices < self.ndim:
     #         for i in range(n_slices, self.ndim):
-    #             var size_at_dim: Int = self.ndshape[i]
+    #             var size_at_dim: Int = self.shape[i]
     #             slice_list.append(Slice(0, size_at_dim))
 
     #     self.__setitem__(slices=slice_list, val=val)
@@ -758,11 +758,11 @@ struct NDArray[dtype: DType = DType.float64](
         ```
         """
         if (
-            mask.ndshape != self.ndshape
+            mask.shape != self.shape
         ):  # this behavious could be removed potentially
             raise Error("Mask and array must have the same shape")
 
-        for i in range(mask.ndshape.ndsize):
+        for i in range(mask.shape.ndsize):
             if mask._buf.load[width=1](i):
                 self._buf.store[width=1](i, val._buf.load[width=1](i))
 
@@ -787,12 +787,12 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
-        if index >= self.ndshape.ndsize:
+        if index >= self.shape.ndsize:
             raise Error("Invalid index: index out of bound")
         if index >= 0:
             return self._buf.load[width=1](index)
         else:
-            return self._buf.load[width=1](index + self.ndshape.ndsize)
+            return self._buf.load[width=1](index + self.shape.ndsize)
 
     fn __getitem__(self, idx: Int) raises -> Self:
         """
@@ -811,14 +811,14 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.ndim > 1:
             for i in range(1, self.ndim):
-                var size_at_dim: Int = self.ndshape[i]
+                var size_at_dim: Int = self.shape[i]
                 slice_list.append(Slice(0, size_at_dim))
 
         var narr: Self = self.__getitem__(slice_list)
 
         if self.ndim == 1:
             narr.ndim = 0
-            narr.ndshape.ndshape[0] = 0
+            narr.shape.shape[0] = 0
 
         return narr
 
@@ -829,7 +829,7 @@ struct NDArray[dtype: DType = DType.float64](
         if index.__len__() != self.ndim:
             raise Error("Error: Length of Indices do not match the shape")
         for i in range(index.__len__()):
-            if index[i] >= self.ndshape[i]:
+            if index[i] >= self.shape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
         var idx: Int = _get_index(index, self.coefficient)
         return self._buf.load[width=1](idx)
@@ -845,12 +845,12 @@ struct NDArray[dtype: DType = DType.float64](
                 raise Error("Error: Number of slices exceeds array dimensions")
 
             var start: Int = 0
-            var end: Int = self.ndshape[i]
+            var end: Int = self.shape[i]
             var step: Int = 1
             if slice_list[i].start is not None:
                 start = slice_list[i].start.value()
                 if start < 0:
-                    # start += self.ndshape[i]
+                    # start += self.shape[i]
                     raise Error(
                         "Error: Negative indexing in slices not supported"
                         " currently"
@@ -859,7 +859,7 @@ struct NDArray[dtype: DType = DType.float64](
             if slice_list[i].end is not None:
                 end = slice_list[i].end.value()
                 if end < 0:
-                    # end += self.ndshape[i] + 1
+                    # end += self.shape[i] + 1
                     raise Error(
                         "Error: Negative indexing in slices not supported"
                         " currently"
@@ -896,7 +896,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
-                slice_list.append(Slice(0, self.ndshape[i]))
+                slice_list.append(Slice(0, self.shape[i]))
 
         var narr: Self = self[slice_list]
         return narr
@@ -920,8 +920,8 @@ struct NDArray[dtype: DType = DType.float64](
         var slices: List[Slice] = self._adjust_slice_(slice_list)
         for i in range(slices.__len__()):
             if (
-                slices[i].start.value() >= self.ndshape[i]
-                or slices[i].end.value() > self.ndshape[i]
+                slices[i].start.value() >= self.shape[i]
+                or slices[i].end.value() > self.shape[i]
             ):
                 raise Error("Error: Slice value exceeds the array shape")
             var slice_len: Int = len(
@@ -1196,14 +1196,14 @@ struct NDArray[dtype: DType = DType.float64](
 
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
-                var size_at_dim: Int = self.ndshape[i]
+                var size_at_dim: Int = self.shape[i]
                 slice_list.append(Slice(0, size_at_dim))
 
         var narr: Self = self.__getitem__(slice_list)
 
         if count_int == self.ndim:
             narr.ndim = 0
-            narr.ndshape.ndshape[0] = 0
+            narr.shape.shape[0] = 0
 
         return narr
 
@@ -1281,11 +1281,11 @@ struct NDArray[dtype: DType = DType.float64](
         # Shape of the result should be
         # Number of indice * shape from dim-1
         # So just change the first number of the ndshape
-        var ndshape = self.ndshape
+        var ndshape = self.shape
         ndshape[0] = len(index)
         ndshape.ndsize = 1
         for i in range(ndshape.ndlen):
-            ndshape.ndsize *= int(ndshape.ndshape[i])
+            ndshape.ndsize *= int(ndshape.shape[i])
         var result = NDArray[dtype](ndshape)
         var size_per_item = ndshape.ndsize // len(index)
 
@@ -1345,7 +1345,7 @@ struct NDArray[dtype: DType = DType.float64](
             NDArray with items from the mask.
         """
         var true: List[Int] = List[Int]()
-        for i in range(mask.ndshape.ndsize):
+        for i in range(mask.shape.ndsize):
             if mask._buf.load[width=1](i):
                 true.append(i)
 
@@ -1621,10 +1621,10 @@ struct NDArray[dtype: DType = DType.float64](
         return self._elementwise_pow(p)
 
     fn __pow__(self, p: Self) raises -> Self:
-        if self.ndshape.ndsize != p.ndshape.ndsize:
+        if self.shape.ndsize != p.shape.ndsize:
             raise Error("Both arrays must have same number of elements")
 
-        var result = Self(self.ndshape)
+        var result = Self(self.shape)
 
         @parameter
         fn vectorized_pow[simd_width: Int](index: Int) -> None:
@@ -1634,7 +1634,7 @@ struct NDArray[dtype: DType = DType.float64](
                 ** p.load[width=simd_width](index),
             )
 
-        vectorize[vectorized_pow, self.width](self.ndshape.ndsize)
+        vectorize[vectorized_pow, self.width](self.shape.ndsize)
         return result
 
     fn __ipow__(inout self, p: Int):
@@ -1649,7 +1649,7 @@ struct NDArray[dtype: DType = DType.float64](
                 index, pow(self._buf.load[width=simd_width](index), p)
             )
 
-        vectorize[array_scalar_vectorize, self.width](self.ndshape.ndsize)
+        vectorize[array_scalar_vectorize, self.width](self.shape.ndsize)
         return new_vec
 
     fn __truediv__(self, other: SIMD[dtype, 1]) raises -> Self:
@@ -1758,7 +1758,7 @@ struct NDArray[dtype: DType = DType.float64](
                 + "\n"
                 + str(self.ndim)
                 + "-D array  "
-                + self.ndshape.__str__()
+                + self.shape.__str__()
                 + "  DType: "
                 + self.dtype.__str__()
             )
@@ -1791,8 +1791,8 @@ struct NDArray[dtype: DType = DType.float64](
                 for i in self:
                     result = result + str(i) + str(",")
             result = result + str("), shape=List[Int](")
-            for i in range(self.ndshape.ndlen):
-                result = result + str(self.ndshape.ndshape[i]) + ","
+            for i in range(self.shape.ndlen):
+                result = result + str(self.shape.shape[i]) + ","
             result = result + str("))")
             return result
         except e:
@@ -1801,7 +1801,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     # Should len be size or number of dimensions instead of the first dimension shape?
     fn __len__(self) -> Int:
-        return int(self.ndshape.ndsize)
+        return int(self.shape.ndsize)
 
     fn __iter__(self) raises -> _NDArrayIter[__lifetime_of(self), dtype]:
         """Iterate over elements of the NDArray, returning copied value.
@@ -1815,7 +1815,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return _NDArrayIter[__lifetime_of(self), dtype](
             array=self,
-            length=self.ndshape[0],
+            length=self.shape[0],
         )
 
     fn __reversed__(
@@ -1830,7 +1830,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return _NDArrayIter[__lifetime_of(self), dtype, forward=False](
             array=self,
-            length=self.ndshape[0],
+            length=self.shape[0],
         )
 
     fn _array_to_string(self, dimension: Int, offset: Int) raises -> String:
@@ -1838,7 +1838,7 @@ struct NDArray[dtype: DType = DType.float64](
             return str(self.item(0))
         if dimension == self.ndim - 1:
             var result: String = str("[\t")
-            var number_of_items = self.ndshape[dimension]
+            var number_of_items = self.shape[dimension]
             if number_of_items <= 6:  # Print all items
                 for i in range(number_of_items):
                     result = (
@@ -1870,7 +1870,7 @@ struct NDArray[dtype: DType = DType.float64](
             return result
         else:
             var result: String = str("[")
-            var number_of_items = self.ndshape[dimension]
+            var number_of_items = self.shape[dimension]
             if number_of_items <= 6:  # Print all items
                 for i in range(number_of_items):
                     if i == 0:
@@ -1930,11 +1930,11 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Inner product of two vectors.
         """
-        if self.ndshape.ndsize != other.ndshape.ndsize:
+        if self.shape.ndsize != other.shape.ndsize:
             raise Error("The lengths of two vectors do not match.")
 
         var sum = Scalar[dtype](0)
-        for i in range(self.ndshape.ndsize):
+        for i in range(self.shape.ndsize):
             sum = sum + self.get(i) * other.get(i)
         return sum
 
@@ -1948,14 +1948,14 @@ struct NDArray[dtype: DType = DType.float64](
         if (self.ndim != 2) or (other.ndim != 2):
             raise Error("The array should have only two dimensions (matrix).")
 
-        if self.ndshape[1] != other.ndshape[0]:
+        if self.shape[1] != other.shape[0]:
             raise Error(
                 "Second dimension of A does not match first dimension of B."
             )
 
-        var new_matrix = Self(self.ndshape[0], other.ndshape[1])
-        for row in range(self.ndshape[0]):
-            for col in range(other.ndshape[1]):
+        var new_matrix = Self(self.shape[0], other.shape[1])
+        for row in range(self.shape[0]):
+            for col in range(other.shape[1]):
                 new_matrix.__setitem__(
                     Idx(row, col),
                     self[row : row + 1, :].vdot(other[:, col : col + 1]),
@@ -1968,7 +1968,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.ndim > 2:
             raise Error("Only support 2-D array (matrix).")
 
-        var width = self.ndshape[1]
+        var width = self.shape[1]
         var buffer = Self(width)
         for i in range(width):
             buffer.set(i, self._buf.load[width=1](i + id * width))
@@ -1980,8 +1980,8 @@ struct NDArray[dtype: DType = DType.float64](
         if self.ndim > 2:
             raise Error("Only support 2-D array (matrix).")
 
-        var width = self.ndshape[1]
-        var height = self.ndshape[0]
+        var width = self.shape[1]
+        var height = self.shape[0]
         var buffer = Self(height)
         for i in range(height):
             buffer.set(i, self._buf.load[width=1](id + i * width))
@@ -1997,16 +1997,16 @@ struct NDArray[dtype: DType = DType.float64](
 
         if (self.ndim != 2) or (other.ndim != 2):
             raise Error("The array should have only two dimensions (matrix).")
-        if self.ndshape.ndshape[1] != other.ndshape.ndshape[0]:
+        if self.shape.shape[1] != other.shape.shape[0]:
             raise Error(
                 "Second dimension of A does not match first dimension of B."
             )
 
-        var new_matrix = Self(self.ndshape[0], other.ndshape[1])
-        for row in range(self.ndshape[0]):
-            for col in range(other.ndshape[1]):
+        var new_matrix = Self(self.shape[0], other.shape[1])
+        for row in range(self.shape[0]):
+            for col in range(other.shape[1]):
                 new_matrix.set(
-                    col + row * other.ndshape[1],
+                    col + row * other.shape[1],
                     self.row(row).vdot(other.col(col)),
                 )
         return new_matrix
@@ -2015,23 +2015,23 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Function to retreive size.
         """
-        return self.ndshape.ndsize
+        return self.shape.ndsize
 
     fn num_elements(self) -> Int:
         """
         Function to retreive size (compatability).
         """
-        return self.ndshape.ndsize
+        return self.shape.ndsize
 
-    # should this return the List[Int] shape and self.ndshape be used instead of making it a no input function call?
+    # should this return the List[Int] shape and self.shape be used instead of making it a no input function call?
     # * We fix return dtype of this array shape for the linalg solve module.
-    fn shape(self) -> NDArrayShape[i32]:
-        """
-        Get the shape as an NDArray Shape.
+    # fn shape(self) -> NDArrayShape[i32]:
+    #     """
+    #     Get the shape as an NDArray Shape.
 
-        To get a list of shape call this then list
-        """
-        return self.ndshape
+    #     To get a list of shape call this then list
+    #     """
+    #     return self.shape
 
     fn load[width: Int = 1](self, index: Int) -> SIMD[dtype, width]:
         """
@@ -2077,8 +2077,8 @@ struct NDArray[dtype: DType = DType.float64](
         """
         if self.ndim != 2:
             raise Error("Only 2-D arrays can be transposed currently.")
-        var rows = self.ndshape[0]
-        var cols = self.ndshape[1]
+        var rows = self.shape[0]
+        var cols = self.shape[1]
 
         var transposed = NDArray[dtype](cols, rows)
         for i in range(rows):
@@ -2103,7 +2103,7 @@ struct NDArray[dtype: DType = DType.float64](
                 (self._buf + idx).strided_load[width=simd_width](1)
             )
 
-        vectorize[vectorized_all, self.width](self.ndshape.ndsize)
+        vectorize[vectorized_all, self.width](self.shape.ndsize)
         return result
 
     fn any(self) raises -> Bool:
@@ -2121,7 +2121,7 @@ struct NDArray[dtype: DType = DType.float64](
                 (self._buf + idx).strided_load[width=simd_width](1)
             )
 
-        vectorize[vectorized_any, self.width](self.ndshape.ndsize)
+        vectorize[vectorized_any, self.width](self.shape.ndsize)
         return result
 
     fn argmax(self) -> Int:
@@ -2130,7 +2130,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var result: Int = 0
         var max_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.ndshape.ndsize):
+        for i in range(1, self.shape.ndsize):
             var temp: SIMD[dtype, 1] = self.load[width=1](i)
             if temp > max_val:
                 max_val = temp
@@ -2143,7 +2143,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var result: Int = 0
         var min_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.ndshape.ndsize):
+        for i in range(1, self.shape.ndsize):
             var temp: SIMD[dtype, 1] = self.load[width=1](i)
             if temp < min_val:
                 min_val = temp
@@ -2167,7 +2167,7 @@ struct NDArray[dtype: DType = DType.float64](
         Convert type of array.
         """
         # I wonder if we can do this operation inplace instead of allocating memory.
-        var narr: NDArray[type] = NDArray[type](self.ndshape, order=self.order)
+        var narr: NDArray[type] = NDArray[type](self.shape, order=self.order)
 
         @parameter
         if type == DType.bool:
@@ -2178,7 +2178,7 @@ struct NDArray[dtype: DType = DType.float64](
                     self.load[simd_width](idx).cast[type](), 1
                 )
 
-            vectorize[vectorized_astype, self.width](self.ndshape.ndsize)
+            vectorize[vectorized_astype, self.width](self.shape.ndsize)
         else:
 
             @parameter
@@ -2196,7 +2196,7 @@ struct NDArray[dtype: DType = DType.float64](
                     )
 
                 vectorize[vectorized_astypenb_from_b, self.width](
-                    self.ndshape.ndsize
+                    self.shape.ndsize
                 )
             else:
 
@@ -2206,7 +2206,7 @@ struct NDArray[dtype: DType = DType.float64](
                         idx, self.load[simd_width](idx).cast[type]()
                     )
 
-                vectorize[vectorized_astypenb, self.width](self.ndshape.ndsize)
+                vectorize[vectorized_astypenb, self.width](self.shape.ndsize)
 
         return narr
 
@@ -2249,7 +2249,7 @@ struct NDArray[dtype: DType = DType.float64](
         fn vectorized_fill[simd_width: Int](index: Int) -> None:
             self._buf.store[width=simd_width](index, val)
 
-        vectorize[vectorized_fill, self.width](self.ndshape.ndsize)
+        vectorize[vectorized_fill, self.width](self.shape.ndsize)
 
         return self
 
@@ -2257,10 +2257,8 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Convert shape of array to one dimensional.
         """
-        self.ndshape = NDArrayShape(
-            self.ndshape.ndsize, size=self.ndshape.ndsize
-        )
-        self.stride = NDArrayStride(shape=self.ndshape, offset=0)
+        self.shape = NDArrayShape(self.shape.ndsize, size=self.shape.ndsize)
+        self.stride = NDArrayStride(shape=self.shape, offset=0)
 
     fn item(self, *index: Int) raises -> SIMD[dtype, 1]:
         """
@@ -2328,7 +2326,7 @@ struct NDArray[dtype: DType = DType.float64](
                 ):  # column-major should be converted to row-major
                     # The following code can be taken out as a function that
                     # convert any index to coordinates according to the order
-                    var c_stride = NDArrayStride(shape=self.ndshape)
+                    var c_stride = NDArrayStride(shape=self.shape)
                     var c_coordinates = List[Int]()
                     var idx: Int = index[0]
                     for i in range(c_stride.ndlen):
@@ -2347,7 +2345,7 @@ struct NDArray[dtype: DType = DType.float64](
         if index.__len__() != self.ndim:
             raise Error("Error: Length of Indices do not match the shape")
         for i in range(index.__len__()):
-            if index[i] >= self.ndshape[i]:
+            if index[i] >= self.shape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
         return self._buf.load[width=1](_get_index(index, self.stride))
 
@@ -2405,7 +2403,7 @@ struct NDArray[dtype: DType = DType.float64](
                 ):  # column-major should be converted to row-major
                     # The following code can be taken out as a function that
                     # convert any index to coordinates according to the order
-                    var c_stride = NDArrayStride(shape=self.ndshape)
+                    var c_stride = NDArrayStride(shape=self.shape)
                     var c_coordinates = List[Int]()
                     for i in range(c_stride.ndlen):
                         var coordinate = idx // c_stride[i]
@@ -2425,7 +2423,7 @@ struct NDArray[dtype: DType = DType.float64](
             if indices.__len__() != self.ndim:
                 raise Error("Error: Length of Indices do not match the shape")
             for i in range(indices.__len__()):
-                if indices[i] >= self.ndshape[i]:
+                if indices[i] >= self.shape[i]:
                     raise Error(
                         "Error: Elements of `index` exceed the array shape"
                     )
@@ -2438,7 +2436,7 @@ struct NDArray[dtype: DType = DType.float64](
         var ndim: Int = self.ndim
         var shape: List[Int] = List[Int]()
         for i in range(ndim):
-            shape.append(self.ndshape[i])
+            shape.append(self.shape[i])
         if axis > ndim - 1:
             raise Error("axis cannot be greater than the rank of the array")
         var result_shape: List[Int] = List[Int]()
@@ -2474,7 +2472,7 @@ struct NDArray[dtype: DType = DType.float64](
         var ndim: Int = self.ndim
         var shape: List[Int] = List[Int]()
         for i in range(ndim):
-            shape.append(self.ndshape[i])
+            shape.append(self.shape[i])
         if axis > ndim - 1:
             raise Error("axis cannot be greater than the rank of the array")
         var result_shape: List[Int] = List[Int]()
@@ -2572,7 +2570,7 @@ struct NDArray[dtype: DType = DType.float64](
             A 1-D List.
         """
         var result: List[Scalar[dtype]] = List[Scalar[dtype]]()
-        for i in range(self.ndshape.ndsize):
+        for i in range(self.shape.ndsize):
             result.append(self._buf[i])
         return result
 

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -19,7 +19,7 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
     # Fields
     var ndsize: Int
     """Total no of elements in the corresponding array."""
-    var ndshape: UnsafePointer[Scalar[dtype]]
+    var shape: UnsafePointer[Scalar[dtype]]
     """Shape of the corresponding array."""
     var ndlen: Int
     """Length of ndshape."""
@@ -34,10 +34,10 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = 1
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             self.ndsize *= shape[i]
 
     @always_inline("nodebug")
@@ -51,11 +51,11 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = size
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         var count: Int = 1
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             count *= shape[i]
         if count != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
@@ -70,10 +70,10 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = 1
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             self.ndsize *= shape[i]
 
     @always_inline("nodebug")
@@ -89,11 +89,11 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
             size  # maybe I should add a check here to make sure it matches
         )
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         var count: Int = 1
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             count *= shape[i]
         if count != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
@@ -108,10 +108,10 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = 1
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             self.ndsize *= shape[i]
 
     @always_inline("nodebug")
@@ -127,11 +127,11 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
             size  # maybe I should add a check here to make sure it matches
         )
         self.ndlen = len(shape)
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
-        memset_zero(self.ndshape, len(shape))
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(len(shape))
+        memset_zero(self.shape, len(shape))
         var count: Int = 1
         for i in range(len(shape)):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
             count *= shape[i]
         if count != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
@@ -146,10 +146,10 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = shape.ndsize
         self.ndlen = shape.ndlen
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(shape.ndlen)
-        memset_zero(self.ndshape, shape.ndlen)
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(shape.ndlen)
+        memset_zero(self.shape, shape.ndlen)
         for i in range(shape.ndlen):
-            self.ndshape[i] = shape[i]
+            self.shape[i] = shape[i]
 
     fn __copy__(inout self, other: Self):
         """
@@ -157,8 +157,8 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         self.ndsize = other.ndsize
         self.ndlen = other.ndlen
-        self.ndshape = UnsafePointer[Scalar[dtype]]().alloc(other.ndlen)
-        memcpy(self.ndshape, other.ndshape, other.ndlen)
+        self.shape = UnsafePointer[Scalar[dtype]]().alloc(other.ndlen)
+        memcpy(self.shape, other.shape, other.ndlen)
 
     @always_inline("nodebug")
     fn __getitem__(self, index: Int) raises -> Int:
@@ -168,9 +168,9 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         if index >= self.ndlen:
             raise Error("Index out of bound")
         if index >= 0:
-            return self.ndshape[index].__int__()
+            return self.shape[index].__int__()
         else:
-            return self.ndshape[self.ndlen + index].__int__()
+            return self.shape[self.ndlen + index].__int__()
 
     @always_inline("nodebug")
     fn __setitem__(inout self, index: Int, val: Int) raises:
@@ -180,9 +180,9 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         if index >= self.ndlen:
             raise Error("Index out of bound")
         if index >= 0:
-            self.ndshape[index] = val
+            self.shape[index] = val
         else:
-            self.ndshape[self.ndlen + index] = val
+            self.shape[self.ndlen + index] = val
 
     @always_inline("nodebug")
     fn size(self) -> Int:
@@ -209,9 +209,9 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         var result: String = "Shape: ["
         for i in range(self.ndlen):
             if i == self.ndlen - 1:
-                result += self.ndshape[i].__str__()
+                result += self.shape[i].__str__()
             else:
-                result += self.ndshape[i].__str__() + ", "
+                result += self.shape[i].__str__() + ", "
         result = result + "]"
         writer.write(result)
 
@@ -250,7 +250,7 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         # if index >= self.ndlen:
         # raise Error("Index out of bound")
-        return self.ndshape.load[width=width](index)
+        return self.shape.load[width=width](index)
 
     # can be used for vectorized index retrieval
     @always_inline("nodebug")
@@ -262,18 +262,18 @@ struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
         """
         # if index >= self.ndlen:
         #     raise Error("Index out of bound")
-        self.ndshape.store[width=width](index, val)
+        self.shape.store[width=width](index, val)
 
     @always_inline("nodebug")
     fn load_int(self, index: Int) -> Int:
         """
         SIMD load dimensional information.
         """
-        return self.ndshape.load[width=1](index).__int__()
+        return self.shape.load[width=1](index).__int__()
 
     @always_inline("nodebug")
     fn store_int(inout self, index: Int, val: Int):
         """
         SIMD store dimensional information.
         """
-        self.ndshape.store[width=1](index, val)
+        self.shape.store[width=1](index, val)

--- a/numojo/core/random.mojo
+++ b/numojo/core/random.mojo
@@ -39,7 +39,7 @@ fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
             "Integral values cannot be sampled between 0 and 1. Use"
             " `rand(*shape, min, max)` instead."
         )
-    for i in range(result.ndshape.ndsize):
+    for i in range(result.shape.ndsize):
         var temp: Scalar[dtype] = random.random_float64(0, 1).cast[dtype]()
         result.set(i, temp)
     return result^
@@ -62,7 +62,7 @@ fn int_rand_func[
     """
     random.randint[dtype](
         ptr=result._buf,
-        size=result.ndshape.ndsize,
+        size=result.shape.ndsize,
         low=int(min),
         high=int(max),
     )
@@ -83,7 +83,7 @@ fn float_rand_func[
         min: The minimum value of the random floating-point numbers.
         max: The maximum value of the random floating-point numbers.
     """
-    for i in range(result.ndshape.ndsize):
+    for i in range(result.shape.ndsize):
         var temp: Scalar[dtype] = random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
@@ -206,7 +206,7 @@ fn randn[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
         ptr=result._buf,
-        size=result.ndshape.ndsize,
+        size=result.shape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
     )
@@ -242,7 +242,7 @@ fn randn[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
         ptr=result._buf,
-        size=result.ndshape.ndsize,
+        size=result.shape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
     )

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -185,8 +185,8 @@ fn binary_sort[
     if dtype != array.dtype:
         alias dtype = array.dtype
 
-    var result: NDArray[dtype] = NDArray[dtype](array.shape())
-    for i in range(array.ndshape.ndsize):
+    var result: NDArray[dtype] = NDArray[dtype](array.shape)
+    for i in range(array.shape.ndsize):
         result.store(i, array.get(i).cast[dtype]())
 
     var n = array.num_elements()

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -196,7 +196,7 @@ fn _traverse_iterative[
         index: The list of indices.
         depth: The depth of the indices.
     """
-    var total_elements = narr.ndshape.ndsize
+    var total_elements = narr.shape.ndsize
 
     # # parallelized version was slower xD
     for _ in range(total_elements):
@@ -246,7 +246,7 @@ fn _traverse_iterative_setter[
         offset: The offset to the first element of the original NDArray.
         index: The list of indices.
     """
-    var total_elements = narr.ndshape.ndsize
+    var total_elements = narr.shape.ndsize
 
     for _ in range(total_elements):
         var orig_idx = offset + _get_index(index, coefficients)
@@ -285,7 +285,7 @@ fn bool_to_numeric[
         The converted NDArray of type `dtype` with 1s (True) and 0s (False).
     """
     # Can't use simd becuase of bit packing error
-    var res: NDArray[dtype] = NDArray[dtype](array.shape())
+    var res: NDArray[dtype] = NDArray[dtype](array.shape)
     for i in range(array.size()):
         var t: Bool = array.item(i)
         if t:
@@ -324,7 +324,7 @@ fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
         var np_arr_dim = PythonObject([])
 
         for i in range(dimension):
-            np_arr_dim.append(array.ndshape[i])
+            np_arr_dim.append(array.shape[i])
 
         # Implement a dictionary for this later
         var numpyarray: PythonObject

--- a/numojo/io/files.mojo
+++ b/numojo/io/files.mojo
@@ -32,9 +32,9 @@ fn savetxt[
     dtype: DType = f64
 ](filename: String, array: NDArray[dtype], delimiter: String = ",") raises:
     var shape: String = "ndshape=["
-    for i in range(array.ndshape.ndlen):
-        shape += str(array.ndshape[i])
-        if i != array.ndshape.ndlen - 1:
+    for i in range(array.shape.ndlen):
+        shape += str(array.shape[i])
+        if i != array.shape.ndlen - 1:
             shape = shape + ", "
     shape = shape + "]"
     print(shape)
@@ -42,7 +42,7 @@ fn savetxt[
     with open(filename, "w") as file:
         file.write(shape + "\n")
         file.write("ndim=[" + str(array.ndim) + "]\n")
-        for i in range(array.ndshape.ndsize):
+        for i in range(array.shape.ndsize):
             if i % 10 == 0:
                 file.write(str("\n"))
             file.write(str(array._buf[i]) + ",")

--- a/numojo/math/arithmetic.mojo
+++ b/numojo/math/arithmetic.mojo
@@ -123,7 +123,7 @@ fn add[
             "math:arithmetic:add(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
             " No arrays in arguaments"
         )
-    var result_array: NDArray[dtype] = NDArray[dtype](array_list[0].shape())
+    var result_array: NDArray[dtype] = NDArray[dtype](array_list[0].shape)
     for array in array_list:
         result_array = add[dtype, backend=backend](result_array, array)
     result_array = add[dtype, backend=backend](result_array, scalar_part)
@@ -432,7 +432,7 @@ fn mul[
             "math:arithmetic:mul(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
             " No arrays in arguaments"
         )
-    var result_array: NDArray[dtype] = NDArray[dtype](array_list[0].shape())
+    var result_array: NDArray[dtype] = NDArray[dtype](array_list[0].shape)
     for array in array_list:
         result_array = mul[dtype, backend=backend](result_array, array)
     result_array = mul[dtype, backend=backend](result_array, scalar_part)

--- a/numojo/math/calculus/differentiation.mojo
+++ b/numojo/math/calculus/differentiation.mojo
@@ -36,7 +36,7 @@ fn gradient[
         The integral of y over x using the trapezoidal rule.
     """
 
-    var result: NDArray[dtype] = NDArray[dtype](x.shape())
+    var result: NDArray[dtype] = NDArray[dtype](x.shape)
     var space: NDArray[dtype] = core.arange[dtype](
         1, x.num_elements() + 1, step=spacing
     )

--- a/numojo/math/calculus/integral.mojo
+++ b/numojo/math/calculus/integral.mojo
@@ -41,7 +41,7 @@ fn trapz[
         ),
     ]()
 
-    if x.shape() != y.shape():
+    if x.shape != y.shape:
         raise Error("x and y must have the same shape")
 
     var integral: Scalar[dtype] = 0.0

--- a/numojo/math/check.mojo
+++ b/numojo/math/check.mojo
@@ -48,7 +48,7 @@ fn isinf[
     """
     # return backend().math_func_is[dtype, math.isinf](array)
 
-    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
+    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size()):
         result_array.store(i, math.isinf(array.get(i)))
     return result_array
@@ -71,7 +71,7 @@ fn isfinite[
         NDArray[DType.bool] - A array of the same shape as `array` with True for finite elements and False for others.
     """
     # return backend().math_func_is[dtype, math.isfinite](array)
-    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
+    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size()):
         result_array.store(i, math.isfinite(array.get(i)))
     return result_array
@@ -94,7 +94,7 @@ fn isnan[
         NDArray[DType.bool] - A array of the same shape as `array` with True for NaN elements and False for others.
     """
     # return backend().math_func_is[dtype, math.isnan](array)
-    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
+    var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size()):
         result_array.store(i, math.isnan(array.get(i)))
     return result_array

--- a/numojo/math/comparison.mojo
+++ b/numojo/math/comparison.mojo
@@ -230,11 +230,11 @@ fn equal[
     return backend().math_func_compare_2_arrays[dtype, SIMD.__eq__](
         array1, array2
     )
-    # if array1.shape() != array2.shape():
+    # if array1.shape != array2.shape:
     #         raise Error(
     #             "Shape Mismatch error shapes must match for this function"
     #         )
-    # var result_array: NDArray[DType.bool] = NDArray[DType.bool](array1.shape())
+    # var result_array: NDArray[DType.bool] = NDArray[DType.bool](array1.shape)
     # for i in range(result_array.size()):
     #     result_array[i] = array1[i]==array2[i]
     # return result_array
@@ -286,11 +286,11 @@ fn not_equal[
     return backend().math_func_compare_2_arrays[dtype, SIMD.__ne__](
         array1, array2
     )
-    # if array1.shape() != array2.shape():
+    # if array1.shape != array2.shape:
     #         raise Error(
     #             "Shape Mismatch error shapes must match for this function"
     #         )
-    # var result_array: NDArray[DType.bool] = NDArray[DType.bool](array1.shape())
+    # var result_array: NDArray[DType.bool] = NDArray[DType.bool](array1.shape)
     # for i in range(result_array.size()):
     #     result_array[i] = array1[i]!=array2[i]
     # return result_array

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -80,7 +80,7 @@ fn _interp1d_linear_interpolate[
     Returns:
         The linearly interpolated values of y at the points xi as An Array of `dtype`.
     """
-    var result = NDArray[dtype](xi.shape())
+    var result = NDArray[dtype](xi.shape)
     for i in range(xi.num_elements()):
         if xi._buf[i] <= x._buf[0]:
             result._buf.store[width=1](i, y._buf[0])
@@ -115,7 +115,7 @@ fn _interp1d_linear_extrapolate[
     Returns:
         The linearly extrapolated values of y at the points xi as An Array of `dtype`.
     """
-    var result = NDArray[dtype](xi.shape())
+    var result = NDArray[dtype](xi.shape)
     for i in range(xi.num_elements()):
         if xi._buf.load[width=1](i) <= x._buf.load[width=1](0):
             var slope = (y._buf[1] - y._buf[0]) / (x._buf[1] - x._buf[0])
@@ -156,7 +156,7 @@ fn _interp1d_linear_extrapolate[
 #     Returns:
 #         The quadratically interpolated values of y at the points xi as An Array of `dtype`.
 #     """
-#     var result = NDArray[dtype](xi.shape())
+#     var result = NDArray[dtype](xi.shape)
 #     for i in range(xi.num_elements()):
 #         if xi[i] <= x[0]:
 #             result[i] = y[0]
@@ -196,7 +196,7 @@ fn _interp1d_linear_extrapolate[
 #     Returns:
 #         The quadratically extrapolated values of y at the points xi as An Array of `dtype`.
 #     """
-#     var result = NDArray[dtype](xi.shape())
+#     var result = NDArray[dtype](xi.shape)
 #     for i in range(xi.num_elements()):
 #         if xi[i] <= x[0]:
 #             var slope = (y[1] - y[0]) / (x[1] - x[0])
@@ -244,7 +244,7 @@ fn _interp1d_linear_extrapolate[
 #     Returns:
 #         The cubically interpolated values of y at the points xi as An Array of `dtype`.
 #     """
-#     var result = NDArray[dtype](xi.shape())
+#     var result = NDArray[dtype](xi.shape)
 #     for i in range(xi.num_elements()):
 #         if xi[i] <= x[0]:
 #             result[i] = y[0]
@@ -296,7 +296,7 @@ fn _interp1d_linear_extrapolate[
 #     Returns:
 #         The cubically extrapolated values of y at the points xi as An Array of `dtype`.
 #     """
-#     var result = NDArray[dtype](xi.shape())
+#     var result = NDArray[dtype](xi.shape)
 #     for i in range(xi.num_elements()):
 #         if (xi[i] <= x[0]):
 #             var t = (xi[i] - x[0]) / (x[1] - x[0])

--- a/numojo/math/linalg/linalg.mojo
+++ b/numojo/math/linalg/linalg.mojo
@@ -35,8 +35,8 @@ fn cross[
         The cross product of two arrays.
     """
 
-    if (array1.ndshape.ndsize == array2.ndshape.ndsize == 3) and (
-        array1.ndshape.ndlen == array2.ndshape.ndlen == 1
+    if (array1.shape.ndsize == array2.shape.ndsize == 3) and (
+        array1.shape.ndlen == array2.shape.ndlen == 1
     ):
         var array3: NDArray[dtype] = NDArray[dtype](NDArrayShape(3))
         array3.store(
@@ -55,9 +55,9 @@ fn cross[
     else:
         raise Error(
             "Cross product is not supported for arrays of shape "
-            + array1.shape().__str__()
+            + array1.shape.__str__()
             + " and "
-            + array2.shape().__str__()
+            + array2.shape.__str__()
         )
 
 
@@ -83,9 +83,9 @@ fn dot[
     """
 
     alias width = simdwidthof[dtype]()
-    if array1.ndshape.ndlen == array2.ndshape.ndlen == 1:
+    if array1.shape.ndlen == array2.shape.ndlen == 1:
         var result: NDArray[dtype] = NDArray[dtype](
-            NDArrayShape(array1.ndshape.ndsize)
+            NDArrayShape(array1.shape.ndsize)
         )
 
         @parameter
@@ -96,12 +96,12 @@ fn dot[
                 * array2.load[width=simd_width](idx),
             )
 
-        vectorize[vectorized_dot, width](array1.ndshape.ndsize)
+        vectorize[vectorized_dot, width](array1.shape.ndsize)
         return result^
     else:
         raise Error(
             "Cross product is not supported for arrays of shape "
-            + array1.shape().__str__()
+            + array1.shape.__str__()
             + " and "
-            + array2.shape().__str__()
+            + array2.shape.__str__()
         )

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -33,11 +33,11 @@ fn matmul_tiled_unrolled_parallelized[
     """
     alias width = max(simdwidthof[dtype](), 16)
     var C: NDArray[dtype] = NDArray[dtype](
-        A.ndshape.load_int(0), B.ndshape.load_int(1)
+        A.shape.load_int(0), B.shape.load_int(1)
     )
-    var t0 = A.ndshape.load_int(0)
-    var t1 = A.ndshape.load_int(1)
-    var t2 = B.ndshape.load_int(1)
+    var t0 = A.shape.load_int(0)
+    var t1 = A.shape.load_int(1)
+    var t2 = B.shape.load_int(1)
 
     @parameter
     fn calculate_A_rows(m: Int):
@@ -121,23 +121,23 @@ fn matmul_parallelized[
         return matmul_1d(A, B)
     elif A.ndim == 1:
         A_reshaped = A
-        A_reshaped.reshape(1, A_reshaped.shape()[0])
+        A_reshaped.reshape(1, A_reshaped.shape[0])
         var res = A_reshaped @ B
-        res.reshape(B.shape()[1])
+        res.reshape(B.shape[1])
         return res
     elif B.ndim == 1:
         B_reshaped = B
-        B_reshaped.reshape(B_reshaped.shape()[0], 1)
+        B_reshaped.reshape(B_reshaped.shape[0], 1)
         var res = A @ B_reshaped
-        res.reshape(A.shape()[0])
+        res.reshape(A.shape[0])
         return res
 
     var C: NDArray[dtype] = zeros[dtype](
-        Shape(A.ndshape.load_int(0), B.ndshape.load_int(1))
+        Shape(A.shape.load_int(0), B.shape.load_int(1))
     )
-    var t0 = A.ndshape.load_int(0)
-    var t1 = A.ndshape.load_int(1)
-    var t2 = B.ndshape.load_int(1)
+    var t0 = A.shape.load_int(0)
+    var t1 = A.shape.load_int(1)
+    var t2 = B.shape.load_int(1)
 
     @parameter
     fn calculate_A_rows(m: Int):
@@ -173,15 +173,15 @@ fn matmul_naive[
     """
     var C: NDArray[dtype]
     if B.ndim == 1:
-        C = zeros[dtype](shape(A.ndshape[0]))
-        for m in range(C.ndshape[0]):
-            for k in range(A.ndshape[1]):
+        C = zeros[dtype](shape(A.shape[0]))
+        for m in range(C.shape[0]):
+            for k in range(A.shape[1]):
                 C.store(m, val=C.load(m) + A.load(m, k) * B.load(k))
     elif B.ndim != 1:
-        C = zeros[dtype](shape(A.ndshape[0], B.ndshape[1]))
-        for m in range(C.ndshape.load_int(0)):
-            for k in range(A.ndshape.load_int(1)):
-                for n in range(C.ndshape.load_int(1)):
+        C = zeros[dtype](shape(A.shape[0], B.shape[1]))
+        for m in range(C.shape.load_int(0)):
+            for k in range(A.shape.load_int(1)):
+                for n in range(C.shape.load_int(1)):
                     C.store(
                         m, n, val=C.load(m, n) + A.load(m, k) * B.load(k, n)
                     )

--- a/numojo/math/linalg/solver.mojo
+++ b/numojo/math/linalg/solver.mojo
@@ -71,7 +71,7 @@ fn lu_decomposition[
         raise ("The array is not 2-dimensional!")
 
     # Check whether the matrix is square
-    var shape_of_array = A.shape()
+    var shape_of_array = A.shape
     if shape_of_array[0] != shape_of_array[1]:
         raise ("The matrix is not square!")
     var n = shape_of_array[0]
@@ -138,7 +138,7 @@ fn forward_substitution[
     """
 
     # length of L
-    var m = L.shape()[0]
+    var m = L.shape[0]
 
     # Initialize x
     var x = NDArray[dtype](m, fill=SIMD[dtype, 1](0))
@@ -172,7 +172,7 @@ fn back_substitution[
     """
 
     # length of U
-    var m = U.shape()[0]
+    var m = U.shape[0]
     # Initialize x
     var x = NDArray[dtype](m, fill=SIMD[dtype, 1](0))
 
@@ -206,7 +206,7 @@ fn inv[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
 
     """
 
-    var m = A.shape()[0]
+    var m = A.shape[0]
     var I = eye[dtype](m, m)
 
     return solve(A, I)
@@ -267,8 +267,8 @@ fn inv_raw[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var L: NDArray[dtype]
     L, U = lu_decomposition[dtype](array)
 
-    var m = array.shape()[0]
-    var inversed = NDArray[dtype](shape=array.shape())
+    var m = array.shape[0]
+    var inversed = NDArray[dtype](shape=array.shape)
 
     # Initialize vectors
     var y = NDArray[dtype](m)
@@ -321,7 +321,7 @@ fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var L: NDArray[dtype]
     L, U = lu_decomposition[dtype](array)
 
-    var m = array.shape()[0]
+    var m = array.shape[0]
 
     var Y = eye[dtype](m, m)
     var Z = zeros[dtype](Shape(m, m))
@@ -409,8 +409,8 @@ fn solve[
     var L: NDArray[dtype]
     L, U = lu_decomposition[dtype](A)
 
-    var m = A.shape()[0]
-    var n = Y.shape()[1]
+    var m = A.shape[0]
+    var n = Y.shape[1]
 
     var Z = zeros[dtype](Shape(m, n))
     var X = zeros[dtype](Shape(m, n))

--- a/numojo/math/math_funcs.mojo
+++ b/numojo/math/math_funcs.mojo
@@ -56,14 +56,11 @@ struct Vectorized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         # var op_count:Int =0
@@ -107,11 +104,11 @@ struct Vectorized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -145,7 +142,7 @@ struct Vectorized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -185,12 +182,12 @@ struct Vectorized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
 
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -227,7 +224,7 @@ struct Vectorized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -249,12 +246,12 @@ struct Vectorized(Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
 
@@ -284,7 +281,7 @@ struct Vectorized(Backend):
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
 
@@ -307,9 +304,7 @@ struct Vectorized(Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -328,7 +323,7 @@ struct Vectorized(Backend):
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -404,14 +399,11 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -453,11 +445,11 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -493,7 +485,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -535,11 +527,11 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -578,7 +570,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -602,12 +594,12 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
 
@@ -638,7 +630,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
 
@@ -663,9 +655,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -686,7 +676,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -740,14 +730,11 @@ struct Parallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -809,11 +796,11 @@ struct Parallelized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -866,7 +853,7 @@ struct Parallelized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -920,11 +907,11 @@ struct Parallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -980,7 +967,7 @@ struct Parallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1011,12 +998,12 @@ struct Parallelized(Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = 1
         var num_cores: Int = num_physical_cores()
@@ -1064,7 +1051,7 @@ struct Parallelized(Backend):
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = 1
         var num_cores: Int = num_physical_cores()
@@ -1099,9 +1086,7 @@ struct Parallelized(Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1135,7 +1120,7 @@ struct Parallelized(Backend):
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -1187,14 +1172,11 @@ struct VectorizedParallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -1261,11 +1243,11 @@ struct VectorizedParallelized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = 1
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -1322,7 +1304,7 @@ struct VectorizedParallelized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1380,11 +1362,11 @@ struct VectorizedParallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -1445,7 +1427,7 @@ struct VectorizedParallelized(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1489,12 +1471,12 @@ struct VectorizedParallelized(Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
@@ -1552,7 +1534,7 @@ struct VectorizedParallelized(Backend):
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
@@ -1597,9 +1579,7 @@ struct VectorizedParallelized(Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = simdwidthof[dtype]()
         var num_cores: Int = num_physical_cores()
         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1637,7 +1617,7 @@ struct VectorizedParallelized(Backend):
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
         @parameter
@@ -1692,13 +1672,13 @@ struct VectorizedParallelized(Backend):
 #         """
 
 #         if (
-#             array1.shape() != array2.shape()
-#             and array1.shape() != array3.shape()
+#             array1.shape != array2.shape
+#             and array1.shape != array3.shape
 #         ):
 #             raise Error(
 #                 "Shape Mismatch error shapes must match for this function"
 #             )
-#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
 #         alias width = simdwidthof[dtype]()
 #         # #var num_cores: Int = num_physical_cores()
 #         # var simd_ops_per_core: Int = width * (array1.num_elements() // width) // num_cores
@@ -1770,11 +1750,11 @@ struct VectorizedParallelized(Backend):
 #         Returns:
 #             A a new NDArray that is NDArray with the function func applied.
 #         """
-#         if array1.shape() != array2.shape():
+#         if array1.shape != array2.shape:
 #             raise Error(
 #                 "Shape Mismatch error shapes must match for this function"
 #             )
-#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
 #         alias width = 1
 #         # var num_cores: Int = num_physical_cores()
 #         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -1831,7 +1811,7 @@ struct VectorizedParallelized(Backend):
 #         Returns:
 #             A a new NDArray that is NDArray with the function func applied.
 #         """
-#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 #         alias width = simdwidthof[dtype]()
 #         # var num_cores: Int = num_physical_cores()
 #         var comps_per_core: Int = array.num_elements() // num_cores
@@ -1889,11 +1869,11 @@ struct VectorizedParallelized(Backend):
 #             A a new NDArray that is NDArray with the function func applied.
 #         """
 
-#         if array1.shape() != array2.shape():
+#         if array1.shape != array2.shape:
 #             raise Error(
 #                 "Shape Mismatch error shapes must match for this function"
 #             )
-#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
 #         alias width = simdwidthof[dtype]()
 #         # var num_cores: Int = num_physical_cores()
 #         var comps_per_core: Int = array1.num_elements() // num_cores
@@ -1953,7 +1933,7 @@ struct VectorizedParallelized(Backend):
 #         Returns:
 #             A a new NDArray that is NDArray with the function func applied.
 #         """
-#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 #         alias width = simdwidthof[dtype]()
 #         var comps_per_core: Int = array.num_elements() // num_cores
 #         var comps_remainder: Int = array.num_elements() % num_cores
@@ -1996,12 +1976,12 @@ struct VectorizedParallelized(Backend):
 #     ](
 #         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
 #     ) raises -> NDArray[DType.bool]:
-#         if array1.shape() != array2.shape():
+#         if array1.shape != array2.shape:
 #             raise Error(
 #                 "Shape Mismatch error shapes must match for this function"
 #             )
 #         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-#             array1.shape()
+#             array1.shape
 #         )
 #         alias width = simdwidthof[dtype]()
 #         # var num_cores: Int = num_physical_cores()
@@ -2059,7 +2039,7 @@ struct VectorizedParallelized(Backend):
 #         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
 #     ) raises -> NDArray[DType.bool]:
 #         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-#             array1.shape()
+#             array1.shape
 #         )
 #         alias width = simdwidthof[dtype]()
 #         # var num_cores: Int = num_physical_cores()
@@ -2105,7 +2085,7 @@ struct VectorizedParallelized(Backend):
 #         ],
 #     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
 #         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-#             array.shape()
+#             array.shape
 #         )
 #         alias width = simdwidthof[dtype]()
 #         # var num_cores: Int = num_physical_cores()
@@ -2144,7 +2124,7 @@ struct VectorizedParallelized(Backend):
 #             type, simd_w
 #         ],
 #     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+#         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 #         alias width = simdwidthof[dtype]()
 
 #         @parameter
@@ -2195,14 +2175,11 @@ struct Naive(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         for i in range(array1.num_elements()):
@@ -2239,11 +2216,11 @@ struct Naive(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 
         for i in range(array1.num_elements()):
@@ -2274,7 +2251,7 @@ struct Naive(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
             var simd_data = func[dtype, 1](array.load[width=1](i))
@@ -2307,11 +2284,11 @@ struct Naive(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
 
         for i in range(array1.num_elements()):
             var simd_data1 = array1.load[width=1](i)
@@ -2343,7 +2320,7 @@ struct Naive(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
             var simd_data1 = array.load[width=1](i)
@@ -2361,12 +2338,12 @@ struct Naive(Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
 
         for i in range(array1.num_elements()):
@@ -2391,7 +2368,7 @@ struct Naive(Backend):
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
 
         for i in range(array1.num_elements()):
@@ -2410,9 +2387,7 @@ struct Naive(Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
 
         for i in range(array.num_elements()):
             var simd_data = func[dtype, 1](array.load[width=1](i))
@@ -2425,7 +2400,7 @@ struct Naive(Backend):
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
             var simd_data1 = array.load[width=1](i)
@@ -2470,14 +2445,11 @@ struct VectorizedVerbose(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if (
-            array1.shape() != array2.shape()
-            and array1.shape() != array3.shape()
-        ):
+        if array1.shape != array2.shape and array1.shape != array3.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
             var simd_data1 = array1.load[width=width](i)
@@ -2525,11 +2497,11 @@ struct VectorizedVerbose(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
             var simd_data1 = array1.load[width=width](i)
@@ -2571,7 +2543,7 @@ struct VectorizedVerbose(Backend):
         Returns:
             A new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
             var simd_data = array.load[width=width](i)
@@ -2612,11 +2584,11 @@ struct VectorizedVerbose(Backend):
             A a new NDArray that is NDArray with the function func applied.
         """
 
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
             var simd_data1 = array1.load[width=width](i)
@@ -2659,7 +2631,7 @@ struct VectorizedVerbose(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
-        var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
             var simd_data1 = array.load[width=width](i)
@@ -2688,12 +2660,12 @@ struct VectorizedVerbose(Backend):
     ](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
-        if array1.shape() != array2.shape():
+        if array1.shape != array2.shape:
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
@@ -2733,7 +2705,7 @@ struct VectorizedVerbose(Backend):
         self: Self, array1: NDArray[dtype], scalar: Scalar[dtype]
     ) raises -> NDArray[DType.bool]:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array1.shape()
+            array1.shape
         )
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
@@ -2764,9 +2736,7 @@ struct VectorizedVerbose(Backend):
             DType.bool, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
-        var result_array: NDArray[DType.bool] = NDArray[DType.bool](
-            array.shape()
-        )
+        var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
             var simd_data = array.load[width=width](i)
@@ -2787,7 +2757,7 @@ struct VectorizedVerbose(Backend):
             type, simd_w
         ],
     ](self: Self, array1: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
-        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape())
+        var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
             var simd_data1 = array1.load[width=width](i)

--- a/numojo/math/signal/signal.mojo
+++ b/numojo/math/signal/signal.mojo
@@ -35,10 +35,10 @@ fn convolve2d[
     for i in range(length):
         in2_mirrored._buf[i] = in2._buf[length - i - 1]
 
-    var in1_height = in1.shape()[0]
-    var in1_width = in1.shape()[1]
-    var in2_height = in2_mirrored.shape()[0]
-    var in2_width = in2_mirrored.shape()[1]
+    var in1_height = in1.shape[0]
+    var in1_width = in1.shape[1]
+    var in2_height = in2_mirrored.shape[0]
+    var in2_width = in2_mirrored.shape[1]
 
     var output_height = in1_height - in2_height + 1
     var output_width = in1_width - in2_width + 1

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -434,10 +434,10 @@ fn minimum[
     Returns:
         The element wise minimum of the two arrays as a array of `dtype`.
     """
-    var result: NDArray[dtype] = NDArray[dtype](array1.shape())
+    var result: NDArray[dtype] = NDArray[dtype](array1.shape)
 
     alias width = simdwidthof[dtype]()
-    if array1.shape() != array2.shape():
+    if array1.shape != array2.shape:
         raise Error("array shapes are not the same")
 
     @parameter
@@ -470,9 +470,9 @@ fn maximum[
         The element wise maximum of the two arrays as a array of `dtype`.
     """
 
-    var result: NDArray[dtype] = NDArray[dtype](array1.shape())
+    var result: NDArray[dtype] = NDArray[dtype](array1.shape)
     alias width = simdwidthof[dtype]()
-    if array1.shape() != array2.shape():
+    if array1.shape != array2.shape:
         raise Error("array shapes are not the same")
 
     @parameter

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -25,7 +25,7 @@ fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
-        shape.append(array.ndshape[i])
+        shape.append(array.shape[i])
     if axis > ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
     var result_shape: List[Int] = List[Int]()
@@ -70,7 +70,7 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
     """
 
     var result = Scalar[array.dtype](0)
-    for i in range(array.ndshape.ndsize):
+    for i in range(array.shape.ndsize):
         result[0] += array._buf[i]
     return result
 
@@ -88,7 +88,7 @@ fn prod(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
-        shape.append(array.ndshape[i])
+        shape.append(array.shape[i])
     if axis > ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
     var result_shape: List[Int] = List[Int]()
@@ -135,7 +135,7 @@ fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
     """
 
     var result = Scalar[array.dtype](1)
-    for i in range(array.ndshape.ndsize):
+    for i in range(array.shape.ndsize):
         result[0] *= array._buf[i]
     return result
 
@@ -150,7 +150,7 @@ fn mean(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
         An NDArray.
 
     """
-    return sum(array, axis) / Scalar[array.dtype](array.ndshape[axis])
+    return sum(array, axis) / Scalar[array.dtype](array.shape[axis])
 
 
 fn meanall(array: NDArray) raises -> Float64:
@@ -177,7 +177,7 @@ fn meanall(array: NDArray) raises -> Float64:
 
     return (
         sumall(array).cast[DType.float64]()
-        / Int32(array.ndshape.ndsize).cast[DType.float64]()
+        / Int32(array.shape.ndsize).cast[DType.float64]()
     )
 
 
@@ -196,7 +196,7 @@ fn max[
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
-        shape.append(array.ndshape[i])
+        shape.append(array.shape[i])
     if axis > ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
     var result_shape: List[Int] = List[Int]()
@@ -243,7 +243,7 @@ fn min[
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
-        shape.append(array.ndshape[i])
+        shape.append(array.shape[i])
     if axis > ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
     var result_shape: List[Int] = List[Int]()

--- a/test.mojo
+++ b/test.mojo
@@ -15,45 +15,45 @@ fn test_constructors1() raises:
     var arr1 = NDArray[f32](3, 4, 5)
     print(arr1)
     print("ndim: ", arr1.ndim)
-    print("shape: ", arr1.ndshape)
+    print("shape: ", arr1.shape)
     print("strides: ", arr1.stride)
-    print("size: ", arr1.ndshape.ndsize)
+    print("size: ", arr1.shape.ndsize)
     print("offset: ", arr1.stride.ndoffset)
     print("dtype: ", arr1.dtype)
 
     var arr2 = NDArray[f32](VariadicList[Int](3, 4, 5))
     print(arr2)
     print("ndim: ", arr2.ndim)
-    print("shape: ", arr2.ndshape)
+    print("shape: ", arr2.shape)
     print("strides: ", arr2.stride)
-    print("size: ", arr2.ndshape.ndsize)
+    print("size: ", arr2.shape.ndsize)
     print("offset: ", arr2.stride.ndoffset)
     print("dtype: ", arr2.dtype)
 
     var arr3 = NDArray[f32](VariadicList[Int](3, 4, 5), fill=Scalar[f32](10.0))
     print(arr3)
     print("ndim: ", arr3.ndim)
-    print("shape: ", arr3.ndshape)
+    print("shape: ", arr3.shape)
     print("strides: ", arr3.stride)
-    print("size: ", arr3.ndshape.ndsize)
+    print("size: ", arr3.shape.ndsize)
     print("offset: ", arr3.stride.ndoffset)
     print("dtype: ", arr3.dtype)
 
     var arr4 = NDArray[f32](List[Int](3, 4, 5))
     print(arr4)
     print("ndim: ", arr4.ndim)
-    print("shape: ", arr4.ndshape)
+    print("shape: ", arr4.shape)
     print("strides: ", arr4.stride)
-    print("size: ", arr4.ndshape.ndsize)
+    print("size: ", arr4.shape.ndsize)
     print("offset: ", arr4.stride.ndoffset)
     print("dtype: ", arr4.dtype)
 
     var arr5 = NDArray[f32](NDArrayShape(3, 4, 5))
     print(arr5)
     print("ndim: ", arr5.ndim)
-    print("shape: ", arr5.ndshape)
+    print("shape: ", arr5.shape)
     print("strides: ", arr5.stride)
-    print("size: ", arr5.ndshape.ndsize)
+    print("size: ", arr5.shape.ndsize)
     print("offset: ", arr5.stride.ndoffset)
     print("dtype: ", arr5.dtype)
 
@@ -63,9 +63,9 @@ fn test_constructors1() raises:
     )
     print(arr6)
     print("ndim: ", arr6.ndim)
-    print("shape: ", arr6.ndshape)
+    print("shape: ", arr6.shape)
     print("strides: ", arr6.stride)
-    print("size: ", arr6.ndshape.ndsize)
+    print("size: ", arr6.shape.ndsize)
     print("offset: ", arr6.stride.ndoffset)
     print("dtype: ", arr6.dtype)
 
@@ -126,9 +126,9 @@ fn test_arr_manipulation() raises:
     print("x[1]", array.item(1))
     print("x[2]", array.item(2))
     # swapaxis(array, 0, -1)
-    # print(array.ndshape)
+    # print(array.shape)
     # swapaxis(array, 0, 2)
-    # print(array.ndshape)
+    # print(array.shape)
     # moveaxis(array, 0, 2)
     # array.reshape(2, 2, 3, order="C")
     # swapaxis(array, 0, 1)
@@ -141,7 +141,7 @@ fn test_arr_manipulation() raises:
 
 fn test_bool_masks1() raises:
     var A = nm.core.random.rand[i16](3, 2, 2)
-    print(A.ndshape)
+    print(A.shape)
     seed(10)
     var B = nm.core.random.rand[i16](3, 2, 2)
     print(B)
@@ -204,7 +204,7 @@ fn test_bool_masks2() raises:
     var temp3 = AA[AA % SIMD[i16, 1](2) == SIMD[i16, 1](0)]
     print(temp3)
     print(temp3.get(0))
-    print(temp3.ndshape, temp3.stride, temp3.ndshape.ndsize)
+    print(temp3.shape, temp3.stride, temp3.shape.ndsize)
 
 
 fn test_creation_routines() raises:
@@ -337,12 +337,12 @@ fn test_rand_funcs[
     if dtype.is_integral():
         randint[dtype](
             ptr=result._buf,
-            size=result.ndshape.ndsize,
+            size=result.shape.ndsize,
             low=int(min),
             high=int(max),
         )
     elif dtype.is_floating_point():
-        for i in range(result.ndshape.ndsize):
+        for i in range(result.shape.ndsize):
             var temp: Scalar[dtype] = random.random_float64(
                 min.cast[f64](), max.cast[f64]()
             ).cast[dtype]()

--- a/tests/test_constructors.mojo
+++ b/tests/test_constructors.mojo
@@ -8,23 +8,23 @@ def test_constructors():
     # Test NDArray constructor with different input types
     var arr1 = NDArray[f32](3, 4, 5)
     assert_true(arr1.ndim == 3, "NDArray constructor: ndim")
-    assert_true(arr1.ndshape[0] == 3, "NDArray constructor: shape element 0")
-    assert_true(arr1.ndshape[1] == 4, "NDArray constructor: shape element 1")
-    assert_true(arr1.ndshape[2] == 5, "NDArray constructor: shape element 2")
-    assert_true(arr1.ndshape.ndsize == 60, "NDArray constructor: size")
+    assert_true(arr1.shape[0] == 3, "NDArray constructor: shape element 0")
+    assert_true(arr1.shape[1] == 4, "NDArray constructor: shape element 1")
+    assert_true(arr1.shape[2] == 5, "NDArray constructor: shape element 2")
+    assert_true(arr1.shape.ndsize == 60, "NDArray constructor: size")
     assert_true(arr1.dtype == DType.float32, "NDArray constructor: dtype")
 
     var arr2 = NDArray[f32](VariadicList[Int](3, 4, 5))
     assert_true(
-        arr2.ndshape[0] == 3,
+        arr2.shape[0] == 3,
         "NDArray constructor with VariadicList: shape element 0",
     )
     assert_true(
-        arr2.ndshape[1] == 4,
+        arr2.shape[1] == 4,
         "NDArray constructor with VariadicList: shape element 1",
     )
     assert_true(
-        arr2.ndshape[2] == 5,
+        arr2.shape[2] == 5,
         "NDArray constructor with VariadicList: shape element 2",
     )
 
@@ -36,26 +36,26 @@ def test_constructors():
 
     var arr4 = NDArray[f32](List[Int](3, 4, 5))
     assert_true(
-        arr4.ndshape[0] == 3, "NDArray constructor with List: shape element 0"
+        arr4.shape[0] == 3, "NDArray constructor with List: shape element 0"
     )
     assert_true(
-        arr4.ndshape[1] == 4, "NDArray constructor with List: shape element 1"
+        arr4.shape[1] == 4, "NDArray constructor with List: shape element 1"
     )
     assert_true(
-        arr4.ndshape[2] == 5, "NDArray constructor with List: shape element 2"
+        arr4.shape[2] == 5, "NDArray constructor with List: shape element 2"
     )
 
     var arr5 = NDArray[f32](NDArrayShape(3, 4, 5))
     assert_true(
-        arr5.ndshape[0] == 3,
+        arr5.shape[0] == 3,
         "NDArray constructor with NDArrayShape: shape element 0",
     )
     assert_true(
-        arr5.ndshape[1] == 4,
+        arr5.shape[1] == 4,
         "NDArray constructor with NDArrayShape: shape element 1",
     )
     assert_true(
-        arr5.ndshape[2] == 5,
+        arr5.shape[2] == 5,
         "NDArray constructor with NDArrayShape: shape element 2",
     )
 
@@ -64,11 +64,11 @@ def test_constructors():
         shape=List[Int](2, 5),
     )
     assert_true(
-        arr6.ndshape[0] == 2,
+        arr6.shape[0] == 2,
         "NDArray constructor with data and shape: shape element 0",
     )
     assert_true(
-        arr6.ndshape[1] == 5,
+        arr6.shape[1] == 5,
         "NDArray constructor with data and shape: shape element 1",
     )
     assert_equal(

--- a/tests/test_random.mojo
+++ b/tests/test_random.mojo
@@ -9,9 +9,9 @@ from testing.testing import assert_true, assert_almost_equal
 def test_rand():
     """Test random array generation with specified shape."""
     var arr = random.rand[nm.f64](3, 5, 2)
-    assert_true(arr.ndshape[0] == 3, "Shape of random array")
-    assert_true(arr.ndshape[1] == 5, "Shape of random array")
-    assert_true(arr.ndshape[2] == 2, "Shape of random array")
+    assert_true(arr.shape[0] == 3, "Shape of random array")
+    assert_true(arr.shape[1] == 5, "Shape of random array")
+    assert_true(arr.shape[2] == 2, "Shape of random array")
 
 
 def test_randminmax():
@@ -101,7 +101,7 @@ def test_randn_list():
         List[Int](20, 20, 20), mean=3.0, variance=1.0
     )
     var arr_list_12 = random.randn[nm.f64](
-        List[Int](20, 20, 20), mean=1.0, variance=3.0
+        List[Int](20, 20, 20), mean=1.0, variance=2.0
     )
 
     var arr_list_mean01 = nm.cummean(arr_list_01)
@@ -144,7 +144,7 @@ def test_randn_list():
     )
     assert_almost_equal(
         arr_list_var12,
-        3,
+        2,
         msg="Variance of random array with mean 1 and variance 2",
         atol=0.1,
     )


### PR DESCRIPTION
To align with numpy (actually to make it more straitforward):

Making `A.shape` the way to get the `NDArrayShape` of an array, instead of `A.shape()` or `A.ndshape`.