### PR TITLE
Use `mojo` package instead of `modular`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,24 +1,24 @@
 [project]
-channels = [
-    "conda-forge",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
+authors = [
+  "Shivasankar <shivasankar.ka@gmail.com>",
+  "MadAlex1997 <>",
+  "Yuhao Zhu (朱宇浩) <dr.yuhao.zhu@outlook.com>",
+  "mmenendezg <>",
+  "sandstromviktor <>",
+  "durnwalder <>",
 ]
+channels = [
+  "conda-forge",
+  "https://conda.modular.com/max",
+  "https://repo.prefix.dev/modular-community",
+]
+description = "NuMojo is a library for numerical computing written in Mojo 🔥"
+license = "Apache-2.0"
+name = "NuMojo"
 platforms = ["osx-arm64", "linux-64"]
 preview = ["pixi-build"]
-name = "NuMojo"
-version = "0.7.0"
-description = "NuMojo is a library for numerical computing written in Mojo 🔥"
-authors = [
-    "Shivasankar <shivasankar.ka@gmail.com>",
-    "MadAlex1997 <>",
-    "Yuhao Zhu (朱宇浩) <dr.yuhao.zhu@outlook.com>",
-    "mmenendezg <>",
-    "sandstromviktor <>",
-    "durnwalder <>",
-]
-license = "Apache-2.0"
 readme = "README.MD"
+version = "0.7.0"
 
 [package]
 name = "numojo"
@@ -26,33 +26,33 @@ version = "0.7.0"
 
 [package.build]
 backend = {name = "pixi-build-mojo", version = "0.*", channels = [
-    "https://prefix.dev/pixi-build-backends",
-    "https://prefix.dev/conda-forge",
+  "https://prefix.dev/pixi-build-backends",
+  "https://prefix.dev/conda-forge",
 ]}
 
 [package.build.config.pkg]
 name = "numojo"
 
 [package.host-dependencies]
-modular = ">=25.6.0,<26"
+mojo = ">=25.6.0,<26"
 
 [package.build-dependencies]
-modular = ">=25.6.0,<26"
+mojo = ">=25.6.0,<26"
 
 [package.run-dependencies]
-modular = ">=25.6.0,<26"
+mojo = ">=25.6.0,<26"
 
 [tasks]
 # compile the package and copy it to the tests folder
-package = "pixi run mojo package numojo && cp numojo.mojopkg tests/"
 p = "clear && pixi run package"
+package = "pixi run mojo package numojo && cp numojo.mojopkg tests/"
 
 # format the package
 format = "pixi run mojo format ./"
 
 # test whether tests pass on the built package
-test = "pixi run package && pixi run mojo test tests -I tests/ && rm tests/numojo.mojopkg"
 t = "clear && pixi run test"
+test = "pixi run package && pixi run mojo test tests -I tests/ && rm tests/numojo.mojopkg"
 
 # run individual tests to avoid overheat
 test_core = "pixi run package && pixi run mojo test tests/core -I tests/ && rm tests/numojo.mojopkg"
@@ -63,13 +63,13 @@ test_linalg = "pixi run package && pixi run mojo test tests/routines/test_linalg
 test_manipulation = "pixi run package && pixi run mojo test tests/routines/test_manipulation.mojo -I tests/ && rm tests/numojo.mojopkg"
 test_math = "pixi run package && pixi run mojo test tests/routines/test_math.mojo -I tests/ && rm tests/numojo.mojopkg"
 test_random = "pixi run package && pixi run mojo test tests/routines/test_random.mojo -I tests/ && rm tests/numojo.mojopkg"
-test_statistics = "pixi run package && pixi run mojo test tests/routines/test_statistics.mojo -I tests/ && rm tests/numojo.mojopkg"
-test_sorting = "pixi run package && pixi run mojo test tests/routines/test_sorting.mojo -I tests/ && rm tests/numojo.mojopkg"
 test_searching = "pixi run package && pixi run mojo test tests/routines/test_searching.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_sorting = "pixi run package && pixi run mojo test tests/routines/test_sorting.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_statistics = "pixi run package && pixi run mojo test tests/routines/test_statistics.mojo -I tests/ && rm tests/numojo.mojopkg"
 
 # run all final checks before a commit
-final = "pixi run format && pixi run test"
 f = "clear && pixi run final"
+final = "pixi run format && pixi run test"
 
 # Automatically Generate doc pages
 doc_pages = "mojo doc numojo/ -o docs.json"
@@ -78,7 +78,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
-python = ">=3.13.5,<3.14"
+mojo = ">=0.25.6,<0.26"
 numpy = ">=2.3.2,<3"
+python = ">=3.13.5,<3.14"
 scipy = ">=1.16.0,<2"
-modular = ">=25.6.0,<26"


### PR DESCRIPTION
Now `mojo` becomes a independent package. We do not need to install `modular` and `max` which include a lot of tools that we do not need.

The version number of `mojo` has a prefix of `0.`. So the latest version is `0.25.6`.